### PR TITLE
Introduce support for vSphere Distributed Network types with no IP Assignment Mode

### DIFF
--- a/api/v1alpha1/networkinterface_types.go
+++ b/api/v1alpha1/networkinterface_types.go
@@ -91,11 +91,6 @@ type NetworkInterfaceStatus struct {
 	IPConfigs []IPConfig `json:"ipConfigs,omitempty"`
 	// MacAddress setting for the network interface.
 	MacAddress string `json:"macAddress,omitempty"`
-	// DHCPDeactivated indicates whether DHCP client configuration is disabled for this interface.
-	// When true, no DHCP client will be configured even if no IP is assigned.
-	// When false or unset (default), DHCP client will be configured if no IP is assigned.
-	// +optional
-	DHCPDeactivated bool `json:"dhcpDeactivated,omitempty"`
 	// ExternalID is a network provider specific identifier assigned to the network interface.
 	ExternalID string `json:"externalID,omitempty"`
 	// NetworkID is an network provider specific identifier for the network backing the network
@@ -109,6 +104,15 @@ type NetworkInterfaceStatus struct {
 	// network interface on the backing network. It is only valid on requested node and is set
 	// only if port allocation was requested.
 	ConnectionID string `json:"connectionID,omitempty"`
+	// IPAssignmentMode indicates how IP addresses are assigned to this interface.
+	// When unset:
+	// - If IP is assigned, it is assumed to be NetworkInterfaceIPAssignmentModeStaticPool.
+	// - If IP is unassigned, it is assumed to be NetworkInterfaceIPAssignmentModeDHCP.
+	// When set to NetworkInterfaceIPAssignmentModeStaticPool, indicates IP is assigned from a static pool.
+	// When set to NetworkInterfaceIPAssignmentModeDHCP, indicates IP should be obtained via DHCP.
+	// When set to NetworkInterfaceIPAssignmentModeNone, indicates no IP assignment should be performed.
+	// +optional
+	IPAssignmentMode NetworkInterfaceIPAssignmentMode `json:"ipAssignmentMode,omitempty"`
 }
 
 type NetworkInterfaceType string
@@ -116,6 +120,20 @@ type NetworkInterfaceType string
 const (
 	// NetworkInterfaceTypeVMXNet3 is for a VMXNET3 device.
 	NetworkInterfaceTypeVMXNet3 = NetworkInterfaceType("vmxnet3")
+)
+
+// NetworkInterfaceIPAssignmentMode defines how IP addresses are assigned to a network interface
+type NetworkInterfaceIPAssignmentMode string
+
+const (
+	// NetworkInterfaceIPAssignmentModeStaticPool indicates IP address is assigned from a static pool.
+	NetworkInterfaceIPAssignmentModeStaticPool NetworkInterfaceIPAssignmentMode = "staticpool"
+
+	// NetworkInterfaceIPAssignmentModeDHCP indicates IP address should be obtained via DHCP.
+	NetworkInterfaceIPAssignmentModeDHCP NetworkInterfaceIPAssignmentMode = "dhcp"
+
+	// NetworkInterfaceIPAssignmentModeNone indicates no IP assignment should be performed.
+	NetworkInterfaceIPAssignmentModeNone NetworkInterfaceIPAssignmentMode = "none"
 )
 
 // NetworkInterfacePortAllocation describes the settings for network interface port allocation request.

--- a/api/v1alpha1/vspheredistributednetwork_types.go
+++ b/api/v1alpha1/vspheredistributednetwork_types.go
@@ -28,9 +28,9 @@ const (
 	IPAssignmentModeDHCP IPAssignmentModeType = "dhcp"
 	// IPAssignmentModeStaticPool indicates IP address is assigned from a static pool of IP addresses.
 	IPAssignmentModeStaticPool IPAssignmentModeType = "staticpool"
-	// IPAssignmentModeSelfManaged indicates that IP assignment is managed by the consuming resource.
+	// IPAssignmentModeNone indicates that no IP assignment will be performed.
 	// The operator will not assign an IP and no DHCP client will be configured.
-	IPAssignmentModeSelfManaged IPAssignmentModeType = "selfmanaged"
+	IPAssignmentModeNone IPAssignmentModeType = "none"
 )
 
 // VSphereDistributedNetworkCondition describes the state of a VSphereDistributedNetwork at a certain point.
@@ -54,24 +54,24 @@ type VSphereDistributedNetworkSpec struct {
 	PortGroupID string `json:"portGroupID"`
 
 	// IPAssignmentMode to use for network interfaces. If unset, defaults to IPAssignmentModeStaticPool.
-	// For IPAssignmentModeDHCP and IPAssignmentModeSelfManaged, the IPPools, Gateway and SubnetMask
-	// fields should be empty/unset. When using IPAssignmentModeSelfManaged, no IP will be assigned
+	// For IPAssignmentModeDHCP and IPAssignmentModeNone, the IPPools, Gateway and SubnetMask
+	// fields should be empty/unset. When using IPAssignmentModeNone, no IP will be assigned
 	// and no DHCP client will be configured.
 	// +optional
 	IPAssignmentMode IPAssignmentModeType `json:"ipAssignmentMode,omitempty"`
 
 	// IPPools references list of IPPool objects. This field should only be set when using
-	// IPAssignmentModeStaticPool. For all other modes (IPAssignmentModeDHCP, IPAssignmentModeSelfManaged), this should be set
+	// IPAssignmentModeStaticPool. For all other modes (IPAssignmentModeDHCP, IPAssignmentModeNone), this should be set
 	// to an empty list.
 	IPPools []IPPoolReference `json:"ipPools"`
 
 	// Gateway setting to use for network interfaces. This field should only be set when using
-	// IPAssignmentModeStaticPool. For all other modes (IPAssignmentModeDHCP, IPAssignmentModeSelfManaged), this should be set
+	// IPAssignmentModeStaticPool. For all other modes (IPAssignmentModeDHCP, IPAssignmentModeNone), this should be set
 	// to an empty string.
 	Gateway string `json:"gateway"`
 
 	// SubnetMask setting to use for network interfaces. This field should only be set when using
-	// IPAssignmentModeStaticPool. For all other modes (IPAssignmentModeDHCP, IPAssignmentModeSelfManaged), this should be set
+	// IPAssignmentModeStaticPool. For all other modes (IPAssignmentModeDHCP, IPAssignmentModeNone), this should be set
 	// to an empty string.
 	SubnetMask string `json:"subnetMask"`
 }


### PR DESCRIPTION
This change introduces the IP Assignment Mode `none` for vSphere Distributed Networks. This network type implies that no IPAM will be managed by Net Operator, and NetworkInterface reconciliation will not provide an IP.

Separate from DHCP, this is a signal to consumers that a DHCP client should not be constructed as the underlying DVPG is not explicitly configured with DHCP. These DVPGs may be desired to be consumed purely for L2 connection, or potentially externally managed IPAM solutions.

Additionally, IP Assignment Mode is reflected in the status of NetworkInterface, to help consumers of only NetworkInterface identify if DHCP/None modes are used without needing to read the underlying Network CR.