### PR TITLE
fix: add missing period in comment per PR feedback

### DIFF
--- a/api/v1alpha1/networkinterface_types.go
+++ b/api/v1alpha1/networkinterface_types.go
@@ -145,7 +145,7 @@ const (
 	NetworkInterfaceIPAssignmentModeNone NetworkInterfaceIPAssignmentMode = "none"
 )
 
-// NetworkInterfaceIPFamilyPolicy defines the IP family policy for a network interface
+// NetworkInterfaceIPFamilyPolicy defines the IP family policy for a network interface.
 type NetworkInterfaceIPFamilyPolicy string
 
 const (


### PR DESCRIPTION
Description:

Fix the comments of https://github.com/vmware-tanzu/net-operator-api/pull/33/changes#r2906473747, add missing period to NetworkInterfaceIPFamilyPolicy comment.