### PR TITLE
Update the VDS IPv6AssignmentMode value when it is unset

### DIFF
--- a/api/v1alpha1/networkinterface_types.go
+++ b/api/v1alpha1/networkinterface_types.go
@@ -72,6 +72,9 @@ const (
 	// NetworkInterfaceFailureReasonNetworkDeleted indicates NetworkInterface is in failed state because
 	// the underlying Network resource has been deleted.
 	NetworkInterfaceFailureReasonNetworkDeleted NetworkInterfaceConditionReason = "NetworkDeleted"
+	// NetworkInterfaceFailureReasonUnsupportedIPFamilyPolicy indicates NetworkInterface is in failed state
+	// because the requested IPFamilyPolicy is not supported by the Network's SupportedIPFamilies.
+	NetworkInterfaceFailureReasonUnsupportedIPFamilyPolicy NetworkInterfaceConditionReason = "UnsupportedIPFamilyPolicy"
 )
 
 // NetworkInterfaceCondition describes the state of a NetworkInterface at a certain point.

--- a/api/v1alpha1/vspheredistributednetwork_types.go
+++ b/api/v1alpha1/vspheredistributednetwork_types.go
@@ -57,13 +57,15 @@ type VSphereDistributedNetworkSpec struct {
 	// For IPAssignmentModeDHCP and IPAssignmentModeNone, the IPPools, Gateway and SubnetMask
 	// fields should be empty/unset. When using IPAssignmentModeNone, no IP will be assigned
 	// and no DHCP client will be configured.
+	// Note: For IPv6 address assignment, see IPv6AssignmentMode.
 	// +optional
 	IPAssignmentMode IPAssignmentModeType `json:"ipAssignmentMode,omitempty"`
 
-	// IPv6AssignmentMode to use for IPv6 addresses on network interfaces in dual-stack setups.
-	// If unset, defaults to the same value as IPAssignmentMode.
-	// This allows different assignment modes for IPv4 and IPv6, for example static IPv4 pool
-	// assignment combined with DHCPv6 for IPv6.
+	// IPv6AssignmentMode to use for IPv6 addresses on network interfaces. If unset, defaults to
+	// IPAssignmentModeNone (IPv6 disabled) for backward compatibility with existing IPv4-only
+	// deployments. To enable IPv6 support, explicitly set this field to IPAssignmentModeStaticPool
+	// or IPAssignmentModeDHCP. This allows different assignment modes for IPv4 and IPv6, for
+	// example static IPv4 pool assignment combined with DHCPv6 for IPv6.
 	// +optional
 	IPv6AssignmentMode IPAssignmentModeType `json:"ipv6AssignmentMode,omitempty"`
 
@@ -82,15 +84,16 @@ type VSphereDistributedNetworkSpec struct {
 	// to an empty string.
 	SubnetMask string `json:"subnetMask"`
 
-	// IPv6Gateway is the default gateway to use for network interfaces for IPv6. This field should
-	// only be set when using IPAssignmentModeStaticPool and dual-stack or IPv6-only mode.
-	// For all other modes (IPAssignmentModeDHCP, IPAssignmentModeNone), this should be empty/unset.
+	// IPv6Gateway setting to use for IPv6 addresses on network interfaces. This field should only
+	// be set when using IPv6AssignmentMode IPAssignmentModeStaticPool. For all other modes
+	// (IPAssignmentModeDHCP, IPAssignmentModeNone), this should be empty/unset.
 	// +optional
 	IPv6Gateway string `json:"ipv6Gateway,omitempty"`
 
 	// IPv6Prefix is the prefix length for IPv6 addresses assigned to network interfaces (e.g. 64
-	// for a /64 network). This field should only be set when using IPAssignmentModeStaticPool and
-	// dual-stack or IPv6-only mode. For all other modes, this should be unset.
+	// for a /64 network). This field should only be set when using IPv6AssignmentMode
+	// IPAssignmentModeStaticPool. For all other modes (IPAssignmentModeDHCP, IPAssignmentModeNone),
+	// this should be unset.
 	// +optional
 	IPv6Prefix *int32 `json:"ipv6Prefix,omitempty"`
 }


### PR DESCRIPTION
Changes:
1. Update the VDS IPv6AssignmentMode value when it is unset 
- **Before**: In the PR https://github.com/vmware-tanzu/net-operator-api/pull/33, if IPv6AssignmentMode is unset, defaults to the same value as IPAssignmentMode.

- **Now**: In this PR, if IPv6AssignmentMode is unset, defaults to IPAssignmentModeNone (IPv6 disabled) for backward compatibility with existing IPv4-only deployments. To enable IPv6 support, explicitly set this field to IPAssignmentModeStaticPool or IPAssignmentModeDHCP.

2. Add a new NetworkInterface FailureReason "UnsupportedIPFamilyPolicy"
-  In the last comment https://github.com/vmware-tanzu/net-operator-api/pull/33/changes#r2906581316, the verification of IPFamilyPolicy was mentioned. When the IPFamilyPolicy request is not supported, net-operator will validate and set clear reasons for failure in the NetworkInterface.Status (UnsupportedIPFamilyPolicy).


Reasons for change-1:

**Design Choices:**

| Option | Description | Pros | Cons |
|--------|-------------|------|------|
| **Before-Option A**: IPv6 inherits IPAssignmentMode | If `IPv6AssignmentMode` is unset, use `IPAssignmentMode` value | Simple configuration | Breaks backward compatibility; existing IPv4-only configs would unexpectedly enable IPv6 |
| **Now-Option B**: IPv6 defaults to None ✓ | If `IPv6AssignmentMode` is unset, default to `none` | Backward compatible, explicit enablement | Requires extra config to enable IPv6 |

**Rationale for Choosing Option B:**

1. **Backward Compatibility** (Most Important)
   - Existing IPv4-only deployments behave exactly the same after upgrade
   - No unexpected IPv6 enablement causing network issues

2. **Explicit Enablement Principle**
   - IPv6 support is a significant feature that should be explicitly enabled by administrators
   - Avoids "surprise" behavior

3. **Industry Convention**
   - Kubernetes Service `ipFamilyPolicy` defaults to `SingleStack`
   - Requires explicit `DualStack` or `PreferDualStack` to enable dual-stack

4. **Avoiding Potential Issues**
   - Auto-enabling IPv6 could cause routing issues, DNS issues, application compatibility issues
   - Administrators need to ensure network infrastructure supports IPv6 before enabling


