### PR TITLE
Fix the IPv6AssignmentMode missed in NetworkInterfaceStatus

### DIFF
--- a/api/v1alpha1/networkinterface_types.go
+++ b/api/v1alpha1/networkinterface_types.go
@@ -35,6 +35,8 @@ type IPConfig struct {
 	// 64 for a /64 IPv6 network). If set, this field takes precedence over SubnetMask
 	// for both IPv4 and IPv6 addresses.
 	// +optional
+	// +kubebuilder:validation:Minimum=0
+	// +kubebuilder:validation:Maximum=128
 	Prefix *int32 `json:"prefix,omitempty"`
 }
 
@@ -116,7 +118,7 @@ type NetworkInterfaceStatus struct {
 	// network interface on the backing network. It is only valid on requested node and is set
 	// only if port allocation was requested.
 	ConnectionID string `json:"connectionID,omitempty"`
-	// IPAssignmentMode indicates how IP addresses are assigned to this interface.
+	// IPAssignmentMode indicates how IPv4 addresses are assigned to this interface.
 	// When unset:
 	// - If IP is assigned, it is assumed to be NetworkInterfaceIPAssignmentModeStaticPool.
 	// - If IP is unassigned, it is assumed to be NetworkInterfaceIPAssignmentModeDHCP.
@@ -125,6 +127,16 @@ type NetworkInterfaceStatus struct {
 	// When set to NetworkInterfaceIPAssignmentModeNone, indicates no IP assignment should be performed.
 	// +optional
 	IPAssignmentMode NetworkInterfaceIPAssignmentMode `json:"ipAssignmentMode,omitempty"`
+	// IPv6AssignmentMode indicates how IPv6 addresses are assigned to this interface.
+	// This field is independent of IPAssignmentMode, allowing different assignment modes for IPv4
+	// and IPv6 (e.g., IPv4 uses DHCP while IPv6 uses static pool).
+	// When unset, defaults to IPAssignmentModeNone (IPv6 disabled) for backward compatibility with existing IPv4-only
+	// deployments.
+	// When set to NetworkInterfaceIPAssignmentModeStaticPool, indicates IPv6 is assigned from a static pool.
+	// When set to NetworkInterfaceIPAssignmentModeDHCP, indicates IPv6 should be obtained via DHCPv6.
+	// When set to NetworkInterfaceIPAssignmentModeNone, indicates no IPv6 assignment should be performed.
+	// +optional
+	IPv6AssignmentMode NetworkInterfaceIPAssignmentMode `json:"ipv6AssignmentMode,omitempty"`
 }
 
 type NetworkInterfaceType string

--- a/api/v1alpha1/vspheredistributednetwork_types.go
+++ b/api/v1alpha1/vspheredistributednetwork_types.go
@@ -54,8 +54,8 @@ type VSphereDistributedNetworkSpec struct {
 	PortGroupID string `json:"portGroupID"`
 
 	// IPAssignmentMode to use for IPv4 addresses on network interfaces. If unset, defaults to IPAssignmentModeStaticPool.
-	// For IPAssignmentModeDHCP and IPAssignmentModeNone, the IPPools, Gateway and SubnetMask
-	// fields should be empty/unset. When using IPAssignmentModeNone, no IP will be assigned
+	// For IPAssignmentModeDHCP and IPAssignmentModeNone, the IPv4 IPPools, Gateway and SubnetMask
+	// fields should be empty/unset. When using IPAssignmentModeNone, no IPv4 IP will be assigned
 	// and no DHCP client will be configured.
 	// Note: For IPv6 address assignment, see IPv6AssignmentMode.
 	// +optional
@@ -95,6 +95,8 @@ type VSphereDistributedNetworkSpec struct {
 	// IPAssignmentModeStaticPool. For all other modes (IPAssignmentModeDHCP, IPAssignmentModeNone),
 	// this should be unset.
 	// +optional
+	// +kubebuilder:validation:Minimum=0
+	// +kubebuilder:validation:Maximum=128
 	IPv6Prefix *int32 `json:"ipv6Prefix,omitempty"`
 }
 


### PR DESCRIPTION
## Background
This PR addresses a critical design gap identified during the implementation of IPv6/Dual-Stack support for net-operator. Following the successful merge of [PR #33](https://github.com/vmware-tanzu/net-operator-api/pull/33) and [PR #35](https://github.com/vmware-tanzu/net-operator-api/pull/35), we discovered that `NetworkInterface.Status` was missing the `IPv6AssignmentMode` field, which is essential for mixed-mode scenarios.

### Problem Statement
**Current State**:
- `VSphereDistributedNetwork` supports independent `IPAssignmentMode` (IPv4) and `IPv6AssignmentMode` (IPv6)
- However, `NetworkInterface.Status` only has a single `IPAssignmentMode` field

**Issue**: In Mixed Mode scenarios (e.g., IPv4=DHCP + IPv6=StaticPool), vm-operator cannot determine how to configure IPv4 and IPv6 separately in the guest OS.

### Backward Compatibility Matrix

| Scenario | IPv6AssignmentMode | Behavior |
|----------|-------------------|----------|
| Old vm-operator | Ignores new field | Continues using IPAssignmentMode, IPv4 works normally |
| New vm-operator | Reads new field | Configures IPv4 and IPv6 independently |
| IPv6AssignmentMode empty | Default | Behaves same as IPAssignmentMode (backward compatible) |

## Test Done
Tested with the net-operator **PR 66708**. Test details could check in that PR test report doc.
```
root@422567b38ee986cc165e262fbca4152b [ ~ ]# kubectl get NetworkInterface -n test-ns minimal-netif -o yaml
apiVersion: netoperator.vmware.com/v1alpha1
kind: NetworkInterface
metadata:
  annotations:
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"netoperator.vmware.com/v1alpha1","kind":"NetworkInterface","metadata":{"annotations":{},"name":"minimal-netif","namespace":"test-ns"},"spec":{"ipFamilyPolicy":"DualStack","networkName":"minimal-network"}}
  creationTimestamp: "2026-04-02T10:24:22Z"
  finalizers:
  - networkinterface.netoperator.vmware.com
  generation: 2
  name: minimal-netif
  namespace: test-ns
  resourceVersion: "1528939"
  uid: 6022dd42-3a4a-4d10-9489-5a30aa27363c
spec:
  ipFamilyPolicy: DualStack
  networkName: minimal-network
status:
  conditions:
  - lastTransitionTime: "2026-04-02T10:24:23Z"
    status: "True"
    type: Ready
  ipAssignmentMode: staticpool
  ipConfigs:
  - gateway: 192.168.200.1
    ip: 192.168.200.100
    ipFamily: IPv4
    prefix: 24
    subnetMask: 255.255.255.0
  - gateway: 2001:db8:300::1
    ip: 2001:db8:300::100
    ipFamily: IPv6
    prefix: 64
    subnetMask: 'ffff:ffff:ffff:ffff::'
  ipv6AssignmentMode: staticpool
  networkID: dvportgroup-63
```
