### PR TITLE
Fix backwards-incompatible API change

### DIFF
--- a/api/v1alpha1/aviloadbalancerconfig_types.go
+++ b/api/v1alpha1/aviloadbalancerconfig_types.go
@@ -129,7 +129,7 @@ type AviLoadBalancerConfig struct {
 	//nolint:kubeapilinter // Stable v1alpha1 retention: avoid Optional value-typed ref (optionalfields pointer churn).
 	Spec AviLoadBalancerConfigSpec `json:"spec,omitempty"`
 
-	// Status reflects the observed state of the Avi load balancer configuration.
+	// Status is unused because AviLoadBalancerConfigSpec is purely a configuration resource.
 	//
 	//nolint:kubeapilinter // Stable v1alpha1 retention: avoid Optional value-typed ref (optionalfields pointer churn).
 	Status AviLoadBalancerConfigStatus `json:"status,omitempty"`

--- a/api/v1alpha1/ipaddressallocation_types.go
+++ b/api/v1alpha1/ipaddressallocation_types.go
@@ -82,8 +82,8 @@ type IPAddressAllocationSpec struct {
 type IPAddressAllocationStatus struct {
 	// IPAddress is the actually allocated IP address.
 	//
-	//nolint:kubeapilinter // Stable v1alpha1 retention: keep value-typed optional string without pointer (optionalfields).
-	IPAddress string `json:"ipAddress,omitempty"`
+	//nolint:kubeapilinter // Stable v1alpha1 retention: keep value-typed optional string without pointer (optionalfields). Keep original json field.
+	IPAddress string `json:"ipaddress,omitempty"`
 
 	// Conditions provide detailed information about the status of the allocation.
 	//

--- a/api/v1alpha1/networkinterface_types.go
+++ b/api/v1alpha1/networkinterface_types.go
@@ -338,6 +338,8 @@ type NetworkInterface struct {
 	Spec NetworkInterfaceSpec `json:"spec,omitempty"`
 
 	// Status defines the observed state of the NetworkInterface.
+	// Once NetworkInterfaceReady condition is True, it should contain configuration to use to place
+	// a VM/Pod/Container's nic on the specified network.
 	//
 	//nolint:kubeapilinter // Stable v1alpha1 retention: keep spec/status value types (optionalfields pointer churn).
 	Status NetworkInterfaceStatus `json:"status,omitempty"`

--- a/api/v1alpha1/networksettings_types.go
+++ b/api/v1alpha1/networksettings_types.go
@@ -34,7 +34,7 @@ type NetworkSettings struct {
 	// +optional
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	// Provider is the active network provider in this namespace. Workloads and network-aware
+	// provider is the active network provider in this namespace. Workloads and network-aware
 	// components should use this to determine which provider governs networking for the namespace,
 	// including when choosing defaulting behavior or which provider-specific APIs to use when not
 	// otherwise specified.

--- a/api/v1alpha1/vspheredistributednetwork_types.go
+++ b/api/v1alpha1/vspheredistributednetwork_types.go
@@ -93,22 +93,22 @@ type VSphereDistributedNetworkSpec struct {
 	IPv6AssignmentMode IPAssignmentModeType `json:"ipv6AssignmentMode,omitempty"`
 
 	// IPPools references list of IPPool objects. This field should only be set when using
-	// IPAssignmentModeStaticPool. For all other modes (IPAssignmentModeDHCP, IPAssignmentModeNone), this should be set
-	// 	to an empty list.
+	// IPAssignmentModeStaticPool. For all other modes (IPAssignmentModeDHCP, IPAssignmentModeNone),
+	// this should be set to an empty list.
 	//
 	//nolint:kubeapilinter // Stable v1alpha1 retention: avoid MaxItems (would tighten validation). Avoid omitempty (requiredfields wire shape).
 	IPPools []IPPoolReference `json:"ipPools"`
 
 	// Gateway is the gateway to use for network interfaces. This field should only be set when using
 	// IPAssignmentModeStaticPool. For all other modes (IPAssignmentModeDHCP, IPAssignmentModeNone), this should be set
-	// 	to an empty string.
+	// to an empty string.
 	//
 	//nolint:kubeapilinter // Stable v1alpha1 retention: avoid MaxLength (would tighten validation). Avoid omitempty (requiredfields wire shape).
 	Gateway string `json:"gateway"`
 
 	// SubnetMask is the subnet mask to use for network interfaces. This field should only be set when using
 	// IPAssignmentModeStaticPool. For all other modes (IPAssignmentModeDHCP, IPAssignmentModeNone), this should be set
-	// 	to an empty string.
+	// to an empty string.
 	//
 	//nolint:kubeapilinter // Stable v1alpha1 retention: avoid MaxLength (would tighten validation). Avoid omitempty (requiredfields wire shape).
 	SubnetMask string `json:"subnetMask"`


### PR DESCRIPTION
`ipaddress` field was changed in JSON which introduced a breaking change (in https://github.com/vmware-tanzu/net-operator-api/commit/1052c9b3cf801f3020477ea0024777eee72e9050). Additionally, some context was lost in CRD translation which has been restored, as well as minor fixes to KAL linting.

Testing Done: Generated CRD definitions and re-applied on a running Kubernetes cluster - no breaking changes occurred. Scanned the CRD definitions and no visual issues presented anymore, either.