### PR TITLE
Remove `nolint:kubeapilinter` directives where reasonable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -120,7 +120,7 @@ lint-shell: ## Lint the project's shell scripts
 	docker run --rm -v "$$(pwd)":/mnt:ro koalaman/shellcheck:stable $$(ls hack/*.sh)
 
 # Kube-API-Linter runs via golangci-lint-kal (Go 1.24+ to build; see hack/tools/Makefile golangci-lint-kal).
-GOLANGCI_LINT_KAL_EXTRA_ARGS ?=
+GOLANGCI_LINT_KAL_EXTRA_ARGS ?= --new-from-merge-base=master # default to new code only
 .PHONY: lint-kal
 lint-kal: $(GOLANGCI_KAL_CONFIG) $(GOLANGCI_LINT_KAL) ## Run kube-api-linter on api/ types
 	$(GOLANGCI_LINT_KAL) run --config $(GOLANGCI_KAL_CONFIG) $(GOLANGCI_LINT_KAL_EXTRA_ARGS) ./api/...

--- a/api/v1alpha1/aviloadbalancerconfig_types.go
+++ b/api/v1alpha1/aviloadbalancerconfig_types.go
@@ -45,37 +45,27 @@ type AviLoadBalancerConfigSpec struct {
 	//   * ADDRESS is the Avi Controller IP address or the Avi Cluster IP when
 	//     two or more Avi Controllers are deployed in cluster mode.
 	//   * PORT defaults to 80 when SCHEME is http and 443 when SCHEME is https.
-	//
-	//nolint:kubeapilinter // Stable v1alpha1 retention: avoid MaxLength (would tighten validation).
 	Server string `json:"server"`
 
 	// CloudName is used by the Avi Kubernetes Operator (AKO) when querying
 	// properties via the Avi REST API, ex. /api/cloud/?name=CLOUD_NAME.
 	// Defaults to Default-Cloud.
 	// +kubebuilder:default:=Default-Cloud
-	//
-	//nolint:kubeapilinter // Stable v1alpha1 retention: keep optional string + kubebuilder:default (do not rewrite to *string / drop default).
 	CloudName string `json:"cloudName,omitempty"`
 
 	// AdvancedL4 is a flag that enables support for WCP in AKO.
 	// Defaults to true.
 	// +kubebuilder:default:=true
-	//
-	//nolint:kubeapilinter // Stable v1alpha1 retention: retain default (ignore kubebuilder:default marker).
 	AdvancedL4 *bool `json:"advancedL4,omitempty"`
 
 	// LogLevel specifies the log level used by AKO.
 	// +kubebuilder:default:=WARN
 	// +kubebuilder:validation:Enum=INFO;DEBUG;WARN;ERROR
-	//
-	//nolint:kubeapilinter // Stable v1alpha1 retention: avoid MaxLength (would tighten validation). Keep optional string without pointer (optionalfields).
 	LogLevel AviLoadBalancerLogLevel `json:"logLevel,omitempty"`
 
 	// IPAMType is the type of IPAM used by the Avi Software Load Balancer.
 	// +kubebuilder:default:=controller
 	// +kubebuilder:validation:Enum=controller;supervisor
-	//
-	//nolint:kubeapilinter // Stable v1alpha1 retention: avoid MaxLength (would tighten validation). Keep optional string without pointer (optionalfields).
 	IPAMType AviLoadBalancerIPAMType `json:"ipamType,omitempty"`
 
 	// CredentialSecretRef points to a Secret resource used to access and
@@ -99,8 +89,6 @@ type AviLoadBalancerConfigSpec struct {
 	//   certificateAuthorityData: []byte
 	//   username: []byte
 	//   password: []byte
-	//
-	//nolint:kubeapilinter // Stable v1alpha1 retention: avoid omitempty (requiredfields wire shape).
 	CredentialSecretRef ClientSecretReference `json:"credentialSecretRef"`
 }
 
@@ -115,8 +103,6 @@ type AviLoadBalancerConfigStatus struct {
 // +kubebuilder:resource:scope=Cluster
 
 // AviLoadBalancerConfig is the Schema for the AviLoadBalancerConfigs API.
-//
-//nolint:kubeapilinter // Stable v1alpha1 retention: ignore kubebuilder:subresource:status marker.
 type AviLoadBalancerConfig struct {
 	metav1.TypeMeta `json:",inline"`
 
@@ -125,13 +111,9 @@ type AviLoadBalancerConfig struct {
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	// Spec describes the desired Avi load balancer configuration.
-	//
-	//nolint:kubeapilinter // Stable v1alpha1 retention: avoid Optional value-typed ref (optionalfields pointer churn).
 	Spec AviLoadBalancerConfigSpec `json:"spec,omitempty"`
 
-	// Status is unused because AviLoadBalancerConfigSpec is purely a configuration resource.
-	//
-	//nolint:kubeapilinter // Stable v1alpha1 retention: avoid Optional value-typed ref (optionalfields pointer churn).
+	// status is unused because AviLoadBalancerConfigSpec is purely a configuration resource.
 	Status AviLoadBalancerConfigStatus `json:"status,omitempty"`
 }
 

--- a/api/v1alpha1/foundationloadbalancerconfig_types.go
+++ b/api/v1alpha1/foundationloadbalancerconfig_types.go
@@ -38,13 +38,9 @@ type FoundationLoadBalancerDeploymentSpec struct {
 	//
 	// +kubebuilder:validation:Enum=small;medium;large;xlarge
 	// +kubebuilder:default:=small
-	//
-	//nolint:kubeapilinter // Stable v1alpha1 retention: keep kubebuilder:default (forbiddenmarkers); CRD defaulting depends on it.
 	Size FoundationLoadBalancerSize `json:"size"`
 
 	// StoragePolicy is a vSphere Storage Policy ID which defines node storage placement.
-	//
-	//nolint:kubeapilinter // Stable v1alpha1 retention: avoid MaxLength (would tighten validation).
 	StoragePolicy string `json:"storagePolicy"`
 
 	// Version number desired by the operator.
@@ -52,21 +48,15 @@ type FoundationLoadBalancerDeploymentSpec struct {
 	// Defaults to the latest available.
 	//
 	// +optional
-	//
-	//nolint:kubeapilinter // Stable v1alpha1 retention: keep optional version string without pointer (optionalfields).
 	Version string `json:"version,omitempty"`
 
 	// Zones contains the names of zones eligible for placing nodes. Zones must be one of the
 	// AvailabilityZones defined and eligible for placement on the cluster.
-	//
-	//nolint:kubeapilinter // Stable v1alpha1 retention: avoid items MaxLength / MaxItems tightening on zone names.
 	Zones []string `json:"zones"`
 
 	// AvailabilityMode defines how the availability of the solution is deployed and configured.
 	// +kubebuilder:validation:Enum=active-passive;single-node
 	// +kubebuilder:default:=active-passive
-	//
-	//nolint:kubeapilinter // Stable v1alpha1 retention: keep kubebuilder:default (forbiddenmarkers).
 	AvailabilityMode FoundationLoadBalancerAvailabilityMode `json:"availabilityMode"`
 
 	// activePassiveSpec configures the load balancer in active-passive configuration.
@@ -95,8 +85,6 @@ type ActivePassiveAvailabilityMode struct {
 	//
 	// +kubebuilder:validation:Maximum=2
 	// +kubebuilder:default:=2
-	//
-	//nolint:kubeapilinter // Stable v1alpha1 retention: keep kubebuilder:default and uint32 (forbiddenmarkers, integers).
 	Replicas uint32 `json:"replicas"`
 }
 
@@ -108,8 +96,6 @@ type SingleNodeAvailabilityMode struct {
 	//
 	// +kubebuilder:validation:Maximum=1
 	// +kubebuilder:default:=1
-	//
-	//nolint:kubeapilinter // Stable v1alpha1 retention: keep kubebuilder:default and uint32 (forbiddenmarkers, integers).
 	Replicas uint32 `json:"replicas"`
 }
 
@@ -118,26 +104,19 @@ type SingleNodeAvailabilityMode struct {
 // FoundationLoadBalancerNodeStatus describes the per-node status of the load balancer.
 type FoundationLoadBalancerNodeStatus struct {
 	// NodeID is a node's unique identifier.
-	//
-	//nolint:kubeapilinter // Stable v1alpha1 retention: avoid MaxLength (would tighten validation).
 	NodeID string `json:"nodeID"`
 
 	// ManagementNetworkInterface defines the management NetworkInterface if it exists.
 	//
 	// +optional
-	//
-	//nolint:kubeapilinter // Stable v1alpha1 retention: keep value-typed optional ref (optionalfields pointer churn).
 	ManagementNetworkInterface NetworkInterfaceReference `json:"managementNetworkInterface,omitempty"`
 
 	// WorkloadNetworkInterfaces define the workload NetworkInterfaces if they exist.
 	//
 	// +optional
-	//nolint:kubeapilinter // Stable v1alpha1 retention: avoid MaxItems (would tighten validation).
 	WorkloadNetworkInterfaces []NetworkInterfaceReference `json:"workloadNetworkInterfaces,omitempty"`
 
 	// VIPNetworkInterface is the interface bound to the Virtual IP Network.
-	//
-	//nolint:kubeapilinter // Stable v1alpha1 retention: keep required value-typed ref (requiredfields pointer churn).
 	VIPNetworkInterface NetworkInterfaceReference `json:"vipNetworkInterface"`
 }
 
@@ -146,37 +125,27 @@ type FoundationLoadBalancerConfigStatus struct {
 	// Version describes the current version of the Foundation Load Balancer.
 	//
 	// +optional
-	//
-	//nolint:kubeapilinter // Stable v1alpha1 retention: avoid MaxLength (would tighten validation). keep optional string without pointer (optionalfields).
 	Version string `json:"version,omitempty"`
 
 	// Nodes list specific information about each deployed node.
 	//
 	// +optional
-	//
-	//nolint:kubeapilinter // Stable v1alpha1 retention: avoid MaxItems (would tighten validation).
 	Nodes []FoundationLoadBalancerNodeStatus `json:"nodes,omitempty"`
 
 	// VirtualServerIPPoolsUtilization describes the current states of virtual server IP addresses utilization.
 	//
 	// +optional
-	//
-	//nolint:kubeapilinter // Stable v1alpha1 retention: keep embedded utilization struct without pointer (optionalfields).
 	VirtualServerIPPoolsUtilization VirtualIPPoolsUtilization `json:"virtualServerIPPoolsUtilization,omitempty"`
 
 	// TokenDigest represents a hash of the current token in JWT format used for authentication with
 	// the load balancer controller.
 	//
 	// +optional
-	//
-	//nolint:kubeapilinter // Stable v1alpha1 retention: keep token digest string without pointer (optionalfields). Avoid MaxLength (would tighten validation).
 	TokenDigest string `json:"tokenDigest,omitempty"`
 
 	// Conditions describes states of the load balancer at specific points in time.
 	//
 	// +optional
-	//
-	//nolint:kubeapilinter // Stable v1alpha1 retention: avoid MaxItems (would tighten validation).
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 }
 
@@ -185,15 +154,11 @@ type VirtualIPPoolsUtilization struct {
 	// IPsAllocated represents the total number of virtual IP addresses currently allocated to services.
 	//
 	// +optional
-	//
-	//nolint:kubeapilinter // Stable v1alpha1 retention: keep int64 counters without pointers (optionalfields).
 	IPsAllocated int64 `json:"ipsAllocated,omitempty"`
 
 	// IPsAvailable represents the total number of virtual IP addresses eligible to be used for services.
 	//
 	// +optional
-	//
-	//nolint:kubeapilinter // Stable v1alpha1 retention: keep int64 counters without pointers (optionalfields).
 	IPsAvailable int64 `json:"ipsAvailable,omitempty"`
 }
 
@@ -201,8 +166,6 @@ type VirtualIPPoolsUtilization struct {
 // This specification is used to configure the resources for the load balancer on vCenter Server.
 type FoundationLoadBalancerConfigSpec struct {
 	// DeploymentSpec describes sizing and placement constraints of the load balancer.
-	//
-	//nolint:kubeapilinter // Stable v1alpha1 retention: keep nested spec without omitzero (requiredfields).
 	DeploymentSpec FoundationLoadBalancerDeploymentSpec `json:"deploymentSpec"`
 
 	// managementNetwork points to the Network used to program node management network interfaces.
@@ -218,21 +181,15 @@ type FoundationLoadBalancerConfigSpec struct {
 	//
 	// +kubebuilder:validation:MaxItems:=1
 	// +optional
-	//
-	//nolint:kubeapilinter // Stable v1alpha1 retention: ignore required listType marker (atomic, set, or map).
 	WorkloadNetworks []NetworkReference `json:"workloadNetworks,omitempty"`
 
 	// VirtualIPNetwork points to the Network used to program node VIP network interfaces.
-	//
-	//nolint:kubeapilinter // Stable v1alpha1 retention: avoid omitempty (requiredfields wire shape).
 	VirtualIPNetwork NetworkReference `json:"virtualIPNetwork"`
 
 	// NetworkSpec contains values for configuring networks on the load balancer.
 	// If unset, default settings will be applied.
 	//
 	// +optional
-	//
-	//nolint:kubeapilinter // Stable v1alpha1 retention: keep value-typed optional nested spec (optionalfields).
 	NetworkSpec FoundationLoadBalancerNetworkConfigSpec `json:"networkSpec,omitempty"`
 }
 
@@ -240,8 +197,6 @@ type FoundationLoadBalancerConfigSpec struct {
 type FoundationLoadBalancerNetworkConfigSpec struct {
 	// VirtualServerIPPools are the list of IPPools that are
 	// used for load balancer IP addresses.
-	//
-	//nolint:kubeapilinter // Stable v1alpha1 retention: avoid MaxItems (would tighten validation).
 	VirtualServerIPPools []IPPoolReference `json:"virtualServerIPPools"`
 
 	// VirtualServerSubnets are the list of subnets specified in CIDR notation
@@ -252,8 +207,6 @@ type FoundationLoadBalancerNetworkConfigSpec struct {
 	//
 	// +kubebuilder:default:={}
 	// +optional
-	//
-	//nolint:kubeapilinter // Stable v1alpha1 retention: keep kubebuilder:default and slice shape (forbiddenmarkers, maxlength items).
 	VirtualServerSubnets []string `json:"virtualServerSubnets"`
 
 	// DNSServers is the list of servers used for DNS traffic.
@@ -262,16 +215,12 @@ type FoundationLoadBalancerNetworkConfigSpec struct {
 	//
 	// +kubebuilder:default:={}
 	// +optional
-	//
-	//nolint:kubeapilinter // Stable v1alpha1 retention: keep kubebuilder:default and slice shape (forbiddenmarkers, maxlength items).
 	DNSServers []string `json:"dnsServers"`
 
 	// DNSSearchDomains are the domains resolvable on the specified DNSServers.
 	//
 	// +kubebuilder:default:={}
 	// +optional
-	//
-	//nolint:kubeapilinter // Stable v1alpha1 retention: keep kubebuilder:default and slice shape (forbiddenmarkers, maxlength items).
 	DNSSearchDomains []string `json:"dnsSearchDomains"`
 
 	// NTPServers are the servers used to sync time across nodes.
@@ -280,8 +229,6 @@ type FoundationLoadBalancerNetworkConfigSpec struct {
 	//
 	// +kubebuilder:default:={}
 	// +optional
-	//
-	//nolint:kubeapilinter // Stable v1alpha1 retention: keep kubebuilder:default and slice shape (forbiddenmarkers, maxlength items).
 	NTPServers []string `json:"ntpServers"`
 
 	// SyslogEndpoint configures the syslog server. It accepts a protocol, host and port.
@@ -293,16 +240,12 @@ type FoundationLoadBalancerNetworkConfigSpec struct {
 	// Defaults to port 514 if using UDP and 6514 if using TLS.
 	//
 	// +optional
-	//
-	//nolint:kubeapilinter // Stable v1alpha1 retention: avoid MaxLength (would tighten validation). Avoid pointer (optionalfields).
 	SyslogEndpoint string `json:"syslogEndpoint,omitempty"`
 
 	// SyslogCertificate is the certificate required to verify
 	// the TLS syslog endpoint in PEM format.
 	//
 	// +optional
-	//
-	//nolint:kubeapilinter // Stable v1alpha1 retention: avoid MaxLength (would tighten validation). Avoid pointer (optionalfields).
 	SyslogCertificate string `json:"syslogCertificate,omitempty"`
 }
 
@@ -320,13 +263,9 @@ type FoundationLoadBalancerConfig struct {
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	// Spec defines the desired state of the Foundation Load Balancer.
-	//
-	//nolint:kubeapilinter // Stable v1alpha1 retention: keep spec/status json tags without omitzero/pointer refactors (optionalfields).
 	Spec FoundationLoadBalancerConfigSpec `json:"spec,omitempty"`
 
 	// Status defines the observed state of the Foundation Load Balancer.
-	//
-	//nolint:kubeapilinter // Stable v1alpha1 retention: keep spec/status json tags without omitzero/pointer refactors (optionalfields).
 	Status FoundationLoadBalancerConfigStatus `json:"status,omitempty"`
 }
 

--- a/api/v1alpha1/haproxyloadbalancerconfig_types.go
+++ b/api/v1alpha1/haproxyloadbalancerconfig_types.go
@@ -20,8 +20,6 @@ type HAProxyLoadBalancerConfigSpec struct {
 	// The strings should include the host, port, and API version, ex.:
 	// https://hostname:port/v1
 	// +kubebuilder:validation:MinItems=1
-	//
-	//nolint:kubeapilinter // Stable v1alpha1 retention: avoid MaxLength (would tighten validation).
 	EndPointURLs []string `json:"endPointURLs"`
 
 	// ServerName is used to verify the hostname on the returned
@@ -30,8 +28,6 @@ type HAProxyLoadBalancerConfigSpec struct {
 	// an IP address.
 	// Defaults to the host part parsed from Server
 	// +optional
-	//
-	//nolint:kubeapilinter // Stable v1alpha1 retention: avoid MaxLength (would tighten validation).
 	ServerName string `json:"serverName,omitempty"`
 
 	// CredentialSecretRef is an object name of kind Secret.
@@ -62,8 +58,6 @@ type HAProxyLoadBalancerConfigSpec struct {
 	//   username: <base64_Encoded>
 	//   password: <base64_Encoded>
 	// +optional
-	//
-	//nolint:kubeapilinter // Stable v1alpha1 retention: avoid Optional value-typed ref (optionalfields pointer churn).
 	CredentialSecretRef ClientSecretReference `json:"credentialSecretRef,omitempty"`
 }
 
@@ -77,8 +71,6 @@ type HAProxyLoadBalancerConfigStatus struct {
 // +kubebuilder:resource:scope=Cluster
 
 // HAProxyLoadBalancerConfig is the Schema for the HAProxyLoadBalancerConfigs API
-//
-//nolint:kubeapilinter // Stable v1alpha1 retention: ignore kubebuilder:subresource:status marker.
 type HAProxyLoadBalancerConfig struct {
 	metav1.TypeMeta `json:",inline"`
 
@@ -87,13 +79,9 @@ type HAProxyLoadBalancerConfig struct {
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	// Spec describes the desired HAProxy load balancer configuration.
-	//
-	//nolint:kubeapilinter // Stable v1alpha1 retention: avoid Optional value-typed ref (optionalfields pointer churn).
 	Spec HAProxyLoadBalancerConfigSpec `json:"spec,omitempty"`
 
 	// Status reflects the observed state of the HAProxy load balancer configuration.
-	//
-	//nolint:kubeapilinter // Stable v1alpha1 retention: avoid Optional value-typed ref (optionalfields pointer churn).
 	Status HAProxyLoadBalancerConfigStatus `json:"status,omitempty"`
 }
 

--- a/api/v1alpha1/ipaddressallocation_types.go
+++ b/api/v1alpha1/ipaddressallocation_types.go
@@ -38,28 +38,18 @@ const (
 // IPAddressAllocationCondition describes the state of an IPAddressAllocation at a specific point in time.
 type IPAddressAllocationCondition struct {
 	// Type is the type of the condition.
-	//
-	//nolint:kubeapilinter // Stable v1alpha1 retention: avoid MaxLength (would tighten validation). Keep condition type without omitempty (requiredfields wire shape).
 	Type IPAddressAllocationConditionType `json:"type"`
 
 	// Status reflects whether the condition is True, False, or Unknown.
-	//
-	//nolint:kubeapilinter // Stable v1alpha1 retention: keep status without omitempty (requiredfields wire shape).
 	Status corev1.ConditionStatus `json:"status"`
 
 	// LastTransitionTime is the timestamp of the last change to the condition's status.
-	//
-	//nolint:kubeapilinter // Stable v1alpha1 retention: avoid MaxLength (would tighten validation). Avoid pointer (optionalfields).
 	LastTransitionTime metav1.Time `json:"lastTransitionTime,omitempty"`
 
 	// Reason provides a machine-readable explanation for the last status transition.
-	//
-	//nolint:kubeapilinter // Stable v1alpha1 retention: avoid MaxLength (would tighten validation). Avoid pointer (optionalfields).
 	Reason IPAddressAllocationConditionReason `json:"reason,omitempty"`
 
 	// Message provides a human-readable explanation for the last status transition.
-	//
-	//nolint:kubeapilinter // Stable v1alpha1 retention: avoid MaxLength (would tighten validation). Avoid pointer (optionalfields).
 	Message string `json:"message,omitempty"`
 }
 
@@ -67,27 +57,19 @@ type IPAddressAllocationCondition struct {
 type IPAddressAllocationSpec struct {
 	// PoolRef is the reference to the network's IP pool within the namespace.
 	// It currently only supports reference to a Network.
-	//
-	//nolint:kubeapilinter // Stable v1alpha1 retention: avoid omitempty (requiredfields wire shape).
 	PoolRef corev1.TypedLocalObjectReference `json:"poolRef"`
 
 	// RequestedIP is an optional field for a user to specify a particular IP they want to request.
 	// If omitted, the system will allocate a single IP address.
-	//
-	//nolint:kubeapilinter // Stable v1alpha1 retention: keep value-typed optional string without pointer (optionalfields).
 	RequestedIP string `json:"requestedIP,omitempty"`
 }
 
 // IPAddressAllocationStatus contains the current status of an IPAddressAllocation, including the allocated IP address and conditions.
 type IPAddressAllocationStatus struct {
 	// IPAddress is the actually allocated IP address.
-	//
-	//nolint:kubeapilinter // Stable v1alpha1 retention: keep value-typed optional string without pointer (optionalfields). Keep original json field.
 	IPAddress string `json:"ipaddress,omitempty"`
 
 	// Conditions provide detailed information about the status of the allocation.
-	//
-	//nolint:kubeapilinter // Stable v1alpha1 retention: keep custom IPAddressAllocationCondition slice (not metav1.Condition).
 	Conditions []IPAddressAllocationCondition `json:"conditions,omitempty"`
 }
 
@@ -95,8 +77,6 @@ type IPAddressAllocationStatus struct {
 // +kubebuilder:object:root=true
 
 // IPAddressAllocation represents a request for IP address allocation, including the desired state and current status.
-//
-//nolint:kubeapilinter // Stable v1alpha1 retention: ignore kubebuilder:subresource:status marker.
 type IPAddressAllocation struct {
 	metav1.TypeMeta `json:",inline"`
 
@@ -105,13 +85,9 @@ type IPAddressAllocation struct {
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	// Spec describes the desired IP address allocation.
-	//
-	//nolint:kubeapilinter // Stable v1alpha1 retention: keep nested spec without omitzero (requiredfields).
 	Spec IPAddressAllocationSpec `json:"spec,omitempty"`
 
 	// Status reflects the observed state of the IP address allocation.
-	//
-	//nolint:kubeapilinter // Stable v1alpha1 retention: keep nested status without omitzero (requiredfields).
 	Status IPAddressAllocationStatus `json:"status,omitempty"`
 }
 

--- a/api/v1alpha1/ippool_types.go
+++ b/api/v1alpha1/ippool_types.go
@@ -54,50 +54,34 @@ const (
 // IPPoolCondition describes the state of a IPPool at a certain point.
 type IPPoolCondition struct {
 	// Type is the type of IPPool condition.
-	//
-	//nolint:kubeapilinter // Stable v1alpha1 retention: avoid MaxLength (would tighten validation).
 	Type IPPoolConditionType `json:"type"`
 
 	// Status is the status of the condition.
 	// Can be True, False, Unknown.
-	//
-	//nolint:kubeapilinter // Stable v1alpha1 retention: keep status without omitempty (requiredfields wire shape).
 	Status corev1.ConditionStatus `json:"status"`
 
 	// Reason is a machine understandable string that gives the reason for condition's last transition.
-	//
-	//nolint:kubeapilinter // Stable v1alpha1 retention: avoid MaxLength (would tighten validation). Avoid pointer (optionalfields).
 	Reason string `json:"reason,omitempty"`
 
 	// Message is a human-readable message indicating details about last transition.
-	//
-	//nolint:kubeapilinter // Stable v1alpha1 retention: avoid MaxLength (would tighten validation). Avoid pointer (optionalfields).
 	Message string `json:"message,omitempty"`
 }
 
 // IPPoolSpec defines the desired state of IPPool.
 type IPPoolSpec struct {
 	// StartingAddress represents the starting IP address of the pool.
-	//
-	//nolint:kubeapilinter // Stable v1alpha1 retention: avoid MaxLength (would tighten validation).
 	StartingAddress string `json:"startingAddress"`
 
 	// AddressCount represents the number of IP addresses in the pool.
-	//
-	//nolint:kubeapilinter // Stable v1alpha1 retention: keep int64 counters without pointers (optionalfields).
 	AddressCount int64 `json:"addressCount"`
 }
 
 // IPPoolStatus defines the current state of IPPool.
 type IPPoolStatus struct {
 	// Allocated represents the number of IP addresses currently allocated to services.
-	//
-	//nolint:kubeapilinter // Stable v1alpha1 retention: keep int64 counters without pointers (optionalfields).
 	Allocated int64 `json:"allocated,omitempty"`
 
 	// Conditions are an array of current observed IPPool conditions.
-	//
-	//nolint:kubeapilinter // Stable v1alpha1 retention: keep custom IPPoolCondition slice (not metav1.Condition).
 	Conditions []IPPoolCondition `json:"conditions,omitempty"`
 }
 
@@ -110,8 +94,6 @@ type IPPoolStatus struct {
 // It represents a pool of IP addresses that are owned and managed by the IPPool controller.
 // Provider specific networks can associate themselves with IPPool objects to use
 // network operator's IPAM implementation.
-//
-//nolint:kubeapilinter // Stable v1alpha1 retention: ignore kubebuilder:subresource:status marker.
 type IPPool struct {
 	metav1.TypeMeta `json:",inline"`
 
@@ -120,26 +102,18 @@ type IPPool struct {
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	// Spec describes the desired IP pool configuration.
-	//
-	//nolint:kubeapilinter // Stable v1alpha1 retention: keep nested spec without omitzero (requiredfields).
 	Spec IPPoolSpec `json:"spec,omitempty"`
 
 	// Status reflects the observed state of the IP pool.
-	//
-	//nolint:kubeapilinter // Stable v1alpha1 retention: keep nested status without omitzero (requiredfields).
 	Status IPPoolStatus `json:"status,omitempty"`
 }
 
 // IPPoolReference is an object that points to a IPPool.
 type IPPoolReference struct {
 	// Name of the IPPool resource being referenced.
-	//
-	//nolint:kubeapilinter // Stable v1alpha1: KAL maxlength (wire shape unchanged).
 	Name string `json:"name"`
 
 	// APIVersion is the API version of the referent.
-	//
-	//nolint:kubeapilinter // Stable v1alpha1: preserve API wire type and markers; new fields should comply with KAL.
 	APIVersion string `json:"apiVersion,omitempty"`
 }
 

--- a/api/v1alpha1/loadbalancerconfig_types.go
+++ b/api/v1alpha1/loadbalancerconfig_types.go
@@ -13,14 +13,10 @@ import (
 // which contains credential specifications for a load balancer.
 type ClientSecretReference struct {
 	// Name is the name of resource being referenced.
-	//
-	//nolint:kubeapilinter // Stable v1alpha1 retention: avoid MaxLength (would tighten validation).
 	Name string `json:"name"`
 
 	// Namespace is the namespace of the resource being referenced. If empty, cluster scoped resource is assumed.
 	// +kubebuilder:default:=default
-	//
-	//nolint:kubeapilinter // Stable v1alpha1 retention: keep optional string without pointer (optionalfields). Retain default (forbiddenmarkers).
 	Namespace string `json:"namespace,omitempty"`
 }
 
@@ -41,54 +37,36 @@ const (
 type LoadBalancerConfigCondition struct {
 	// Type is the type of load balancer condition
 	// Can be Ready or Failure
-	//
-	//nolint:kubeapilinter // Stable v1alpha1 retention: avoid MaxLength (would tighten validation).
 	Type LoadBalancerConfigConditionType `json:"type"`
 
 	// Status is the status of the condition
 	// Can be True, False, Unknown
-	//
-	//nolint:kubeapilinter // Stable v1alpha1 retention: keep status without omitempty (requiredfields wire shape).
 	Status corev1.ConditionStatus `json:"status"`
 
 	// Reason is a machine understandable string that gives the reason for the condition's last transition.
 	// +optional
-	//
-	//nolint:kubeapilinter // Stable v1alpha1 retention: avoid MaxLength (would tighten validation). Avoid pointer (optionalfields).
 	Reason string `json:"reason,omitempty"`
 
 	// Message is a human-readable message indicating details about last transition.
 	// +optional
-	//
-	//nolint:kubeapilinter // Stable v1alpha1 retention: avoid MaxLength (would tighten validation). Avoid pointer (optionalfields).
 	Message string `json:"message,omitempty"`
 
 	// LastTransitionTime is the timestamp for when the LoadBalancerConfig object last transitioned from one status to another.
-	//
-	//nolint:kubeapilinter // Stable v1alpha1 retention: avoid MaxLength (would tighten validation). Avoid pointer (optionalfields).
 	LastTransitionTime metav1.Time `json:"lastTransitionTime,omitempty" patchStrategy:"replace"`
 }
 
 // LoadBalancerConfigProviderReference represents the specific load balancer instance that needs to be configured
 type LoadBalancerConfigProviderReference struct {
 	// APIGroup is the group for the resource being referenced
-	//
-	//nolint:kubeapilinter // Stable v1alpha1 retention: avoid MaxLength (would tighten validation).
 	APIGroup string `json:"apiGroup"`
 
 	// Kind is the type of resource being referenced
-	//
-	//nolint:kubeapilinter // Stable v1alpha1 retention: avoid MaxLength (would tighten validation). Avoid omitempty (requiredfields wire shape).
 	Kind string `json:"kind"`
 
 	// Name is the name of resource being referenced
-	//
-	//nolint:kubeapilinter // Stable v1alpha1 retention: avoid MaxLength (would tighten validation). Avoid omitempty (requiredfields wire shape).
 	Name string `json:"name"`
 
 	// APIVersion is the API version of the referent.
-	//
-	//nolint:kubeapilinter // Stable v1alpha1 retention: keep optional string without pointer (optionalfields).
 	APIVersion string `json:"apiVersion,omitempty"`
 }
 
@@ -109,21 +87,15 @@ const (
 type LoadBalancerConfigSpec struct {
 	// Type describes type of load balancer.
 	// +kubebuilder:validation:Enum=haproxy;avi;foundation
-	//
-	//nolint:kubeapilinter // Stable v1alpha1 retention: avoid MaxLength (would tighten validation). Keep type without omitempty (requiredfields wire shape).
 	Type LoadBalancerConfigType `json:"type"`
 
 	// ProviderRef is reference to a load balancer provider object that provides the details for this type of load balancer
-	//
-	//nolint:kubeapilinter // Stable v1alpha1 retention: avoid MaxLength (would tighten validation). Avoid omitempty (requiredfields wire shape).
 	ProviderRef LoadBalancerConfigProviderReference `json:"providerRef"`
 }
 
 // LoadBalancerConfigStatus defines the observed state of LoadBalancerConfig
 type LoadBalancerConfigStatus struct {
 	// Conditions are an array of current observed load balancer conditions
-	//
-	//nolint:kubeapilinter // Stable v1alpha1 retention: keep custom LoadBalancerConfigCondition slice (not metav1.Condition).
 	Conditions []LoadBalancerConfigCondition `json:"conditions,omitempty"`
 }
 
@@ -133,8 +105,6 @@ type LoadBalancerConfigStatus struct {
 // +kubebuilder:resource:scope=Cluster
 
 // LoadBalancerConfig is the Schema for the LoadBalancerConfigs API
-//
-//nolint:kubeapilinter // Stable v1alpha1 retention: ignore kubebuilder:subresource:status marker.
 type LoadBalancerConfig struct {
 	metav1.TypeMeta `json:",inline"`
 
@@ -143,13 +113,9 @@ type LoadBalancerConfig struct {
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	// Spec describes the desired load balancer configuration.
-	//
-	//nolint:kubeapilinter // Stable v1alpha1 retention: keep nested spec without omitzero (requiredfields).
 	Spec LoadBalancerConfigSpec `json:"spec,omitempty"`
 
 	// Status reflects the observed state of the load balancer configuration.
-	//
-	//nolint:kubeapilinter // Stable v1alpha1 retention: keep nested status without omitzero (requiredfields).
 	Status LoadBalancerConfigStatus `json:"status,omitempty"`
 }
 

--- a/api/v1alpha1/network_types.go
+++ b/api/v1alpha1/network_types.go
@@ -34,28 +34,18 @@ const (
 // NetworkProviderReference contains info to locate a network provider object.
 type NetworkProviderReference struct {
 	// APIGroup is the group for the resource being referenced.
-	//
-	//nolint:kubeapilinter // Stable v1alpha1 retention: avoid MaxLength (would tighten validation). Avoid omitempty (requiredfields wire shape).
 	APIGroup string `json:"apiGroup"`
 
 	// Kind is the type of resource being referenced.
-	//
-	//nolint:kubeapilinter // Stable v1alpha1 retention: avoid MaxLength (would tighten validation). Avoid omitempty (requiredfields wire shape).
 	Kind string `json:"kind"`
 
 	// Name is the name of resource being referenced.
-	//
-	//nolint:kubeapilinter // Stable v1alpha1 retention: avoid MaxLength (would tighten validation). Avoid omitempty (requiredfields wire shape).
 	Name string `json:"name"`
 
 	// Namespace is the namespace of the resource being referenced. If empty, cluster scoped resource is assumed.
-	//
-	//nolint:kubeapilinter // Stable v1alpha1 retention: keep optional string without pointer (optionalfields). Retain default (forbiddenmarkers).
 	Namespace string `json:"namespace,omitempty"`
 
 	// APIVersion is the API version of the referent.
-	//
-	//nolint:kubeapilinter // Stable v1alpha1 retention: keep optional string without pointer (optionalfields).
 	APIVersion string `json:"apiVersion,omitempty"`
 }
 
@@ -76,58 +66,38 @@ const (
 // NetworkSpec defines the state of Network.
 type NetworkSpec struct {
 	// Type describes type of Network. Supported values are nsx-t, vsphere-distributed.
-	//
-	//nolint:kubeapilinter // Stable v1alpha1 retention: avoid MaxLength (would tighten validation). Keep type without omitempty (requiredfields wire shape).
 	Type NetworkType `json:"type"`
 
 	// ProviderRef is reference to a network provider object that provides this type of network.
-	//
-	//nolint:kubeapilinter // Stable v1alpha1 retention: avoid omitempty (requiredfields wire shape).
 	ProviderRef NetworkProviderReference `json:"providerRef"`
 
 	// DNS is a list of DNS server IPs to associate with network interfaces on this network.
-	//
-	//nolint:kubeapilinter // Stable v1alpha1 retention: avoid MaxLength (would tighten validation). Keep slice without omitempty (optionalfields wire shape).
 	DNS []string `json:"dns,omitempty"`
 
 	// DNSSearchDomains is a list of DNS search domains to associate with network interfaces on this network.
-	//
-	//nolint:kubeapilinter // Stable v1alpha1 retention: avoid MaxLength (would tighten validation). Keep slice without omitempty (optionalfields wire shape).
 	DNSSearchDomains []string `json:"dnsSearchDomains,omitempty"`
 
 	// NTP is a list of NTP server DNS names or IP addresses to use on this network.
-	//
-	//nolint:kubeapilinter // Stable v1alpha1 retention: avoid MaxLength (would tighten validation). Keep slice without omitempty (optionalfields wire shape).
 	NTP []string `json:"ntp,omitempty"`
 }
 
 // NetworkCondition describes the state of a Network at a certain point.
 type NetworkCondition struct {
 	// Type is the type of network condition.
-	//
-	//nolint:kubeapilinter // Stable v1alpha1 retention: avoid MaxLength (would tighten validation). Keep condition type without omitempty (requiredfields wire shape).
 	Type NetworkConditionType `json:"type"`
 
 	// Status is the status of the condition.
 	// Can be True, False, Unknown.
-	//
-	//nolint:kubeapilinter // Stable v1alpha1 retention: keep status without omitempty (requiredfields wire shape).
 	Status corev1.ConditionStatus `json:"status"`
 
 	// LastTransitionTime is the timestamp corresponding to the last status
 	// change of this condition.
-	//
-	//nolint:kubeapilinter // Stable v1alpha1 retention: avoid MaxLength (would tighten validation). Avoid pointer (optionalfields).
 	LastTransitionTime metav1.Time `json:"lastTransitionTime,omitempty"`
 
 	// Reason is a machine understandable string that gives the reason for condition's last transition.
-	//
-	//nolint:kubeapilinter // Stable v1alpha1 retention: avoid MaxLength (would tighten validation). Avoid pointer (optionalfields).
 	Reason NetworkConditionReason `json:"reason,omitempty"`
 
 	// Message is a human-readable message indicating details about last transition.
-	//
-	//nolint:kubeapilinter // Stable v1alpha1 retention: avoid MaxLength (would tighten validation). Avoid pointer (optionalfields).
 	Message string `json:"message,omitempty"`
 }
 
@@ -135,8 +105,6 @@ type NetworkCondition struct {
 type NetworkStatus struct {
 	// Conditions are an array of current observed network conditions.
 	// +optional
-	//
-	//nolint:kubeapilinter // Stable v1alpha1 retention: keep custom NetworkCondition slice (not metav1.Condition).
 	Conditions []NetworkCondition `json:"conditions,omitempty"`
 
 	// SupportedIPFamilies list the IP families that are available on this network,
@@ -145,28 +113,20 @@ type NetworkStatus struct {
 	// to understand which IPFamilyPolicy values are valid when creating a NetworkInterface
 	// on this network.
 	// +optional
-	//
-	//nolint:kubeapilinter // Stable v1alpha1 retention: avoid MaxItems (would tighten validation).
 	SupportedIPFamilies []corev1.IPFamily `json:"supportedIPFamilies,omitempty"`
 }
 
 // NetworkReference is an object that points to a Network.
 type NetworkReference struct {
 	// Kind is the type of resource being referenced.
-	//
-	//nolint:kubeapilinter // Stable v1alpha1 retention: avoid MaxLength (would tighten validation). Avoid omitempty (requiredfields wire shape).
 	Kind string `json:"kind"`
 
 	// Name is the name of resource being referenced.
-	//
-	//nolint:kubeapilinter // Stable v1alpha1 retention: avoid MaxLength (would tighten validation). Avoid omitempty (requiredfields wire shape).
 	Name string `json:"name"`
 
 	// APIVersion of the referent.
 	//
 	// +optional
-	//
-	//nolint:kubeapilinter // Stable v1alpha1 retention: keep optional string without pointer (optionalfields).
 	APIVersion string `json:"apiVersion,omitempty"`
 }
 
@@ -185,13 +145,9 @@ type Network struct {
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	// Spec describes the desired network configuration.
-	//
-	//nolint:kubeapilinter // Stable v1alpha1 retention: keep nested spec without omitzero (requiredfields).
 	Spec NetworkSpec `json:"spec,omitempty"`
 
 	// Status reflects the observed state of the network.
-	//
-	//nolint:kubeapilinter // Stable v1alpha1 retention: keep nested status without omitzero (requiredfields).
 	Status NetworkStatus `json:"status,omitempty"`
 }
 

--- a/api/v1alpha1/networkinterface_types.go
+++ b/api/v1alpha1/networkinterface_types.go
@@ -23,24 +23,16 @@ const (
 // IPConfig represents an IP configuration.
 type IPConfig struct {
 	// IP is the IP address for this configuration.
-	//
-	//nolint:kubeapilinter // Stable v1alpha1 retention: avoid MaxLength (would tighten validation).
 	IP string `json:"ip"`
 
 	// IPFamily specifies the IP family (IPv4 vs IPv6) the IP belongs to.
-	//
-	//nolint:kubeapilinter // Stable v1alpha1 retention: avoid MaxLength (would tighten validation). Avoid omitempty (requiredfields wire shape).
 	IPFamily corev1.IPFamily `json:"ipFamily"`
 
 	// Gateway is the default gateway for this configuration.
-	//
-	//nolint:kubeapilinter // Stable v1alpha1 retention: avoid MaxLength (would tighten validation).
 	Gateway string `json:"gateway"`
 
 	// SubnetMask is the subnet mask for this configuration.
 	// Deprecated: Use Prefix instead. If Prefix is set, SubnetMask is ignored.
-	//
-	//nolint:kubeapilinter // Stable v1alpha1 retention: avoid MaxLength (would tighten validation).
 	SubnetMask string `json:"subnetMask"`
 
 	// prefix is the prefix length for the IP address (e.g. 24 for a /24 IPv4 network,
@@ -55,23 +47,15 @@ type IPConfig struct {
 // NetworkInterfaceProviderReference contains info to locate a network interface provider object.
 type NetworkInterfaceProviderReference struct {
 	// APIGroup is the group for the resource being referenced.
-	//
-	//nolint:kubeapilinter // Stable v1alpha1 retention: avoid MaxLength (would tighten validation).
 	APIGroup string `json:"apiGroup"`
 
 	// Kind is the type of resource being referenced.
-	//
-	//nolint:kubeapilinter // Stable v1alpha1 retention: avoid MaxLength (would tighten validation).
 	Kind string `json:"kind"`
 
 	// Name is the name of resource being referenced.
-	//
-	//nolint:kubeapilinter // Stable v1alpha1 retention: avoid MaxLength (would tighten validation).
 	Name string `json:"name"`
 
 	// APIVersion is the API version of the referent.
-	//
-	//nolint:kubeapilinter // Stable v1alpha1 retention: keep optional string without pointer (optionalfields).
 	APIVersion string `json:"apiVersion,omitempty"`
 }
 
@@ -108,14 +92,10 @@ const (
 // NetworkInterfaceCondition describes the state of a NetworkInterface at a certain point.
 type NetworkInterfaceCondition struct {
 	// Type is the type of network interface condition.
-	//
-	//nolint:kubeapilinter // Stable v1alpha1 retention: avoid MaxLength (would tighten validation). Keep condition type without omitempty (requiredfields wire shape).
 	Type NetworkInterfaceConditionType `json:"type"`
 
 	// Status is the status of the condition.
 	// Can be True, False, Unknown.
-	//
-	//nolint:kubeapilinter // Stable v1alpha1 retention: keep status without omitempty (requiredfields wire shape).
 	Status corev1.ConditionStatus `json:"status"`
 
 	// lastTransitionTime is the timestamp corresponding to the last status
@@ -124,13 +104,9 @@ type NetworkInterfaceCondition struct {
 	LastTransitionTime metav1.Time `json:"lastTransitionTime,omitempty"`
 
 	// Reason is a machine understandable string that gives the reason for condition's last transition.
-	//
-	//nolint:kubeapilinter // Stable v1alpha1 retention: avoid MaxLength (would tighten validation). Avoid pointer (optionalfields).
 	Reason NetworkInterfaceConditionReason `json:"reason,omitempty"`
 
 	// Message is a human-readable message indicating details about last transition.
-	//
-	//nolint:kubeapilinter // Stable v1alpha1 retention: avoid MaxLength (would tighten validation). Avoid pointer (optionalfields).
 	Message string `json:"message,omitempty"`
 }
 
@@ -139,43 +115,29 @@ type NetworkInterfaceCondition struct {
 // a VM/Pod/Container's nic on the specified network.
 type NetworkInterfaceStatus struct {
 	// Conditions are an array of current observed network interface conditions.
-	//
-	//nolint:kubeapilinter // Stable v1alpha1 retention: keep custom NetworkInterfaceCondition slice (not metav1.Condition).
 	Conditions []NetworkInterfaceCondition `json:"conditions,omitempty"`
 
 	// IPConfigs are an array of IP configurations for the network interface.
-	//
-	//nolint:kubeapilinter // Stable v1alpha1 retention: avoid MaxItems (would tighten validation).
 	IPConfigs []IPConfig `json:"ipConfigs,omitempty"`
 
 	// MacAddress is the MAC address for the network interface.
-	//
-	//nolint:kubeapilinter // Stable v1alpha1 retention: avoid MaxLength (would tighten validation). Avoid pointer (optionalfields).
 	MacAddress string `json:"macAddress,omitempty"`
 
 	// ExternalID is a network provider specific identifier assigned to the network interface.
-	//
-	//nolint:kubeapilinter // Stable v1alpha1 retention: avoid MaxLength (would tighten validation). Avoid pointer (optionalfields).
 	ExternalID string `json:"externalID,omitempty"`
 
 	// NetworkID is a network provider specific identifier for the network backing the network
 	// interface.
-	//
-	//nolint:kubeapilinter // Stable v1alpha1 retention: avoid MaxLength (would tighten validation). Avoid pointer (optionalfields).
 	NetworkID string `json:"networkID,omitempty"`
 
 	// PortID is a network provider specific port identifier allocated for this network interface on
 	// the backing network. It is only valid on requested node and is set only if port allocation
 	// was requested.
-	//
-	//nolint:kubeapilinter // Stable v1alpha1 retention: avoid MaxLength (would tighten validation). Avoid pointer (optionalfields).
 	PortID string `json:"portID,omitempty"`
 
 	// ConnectionID is a network provider specific port connection identifier allocated for this
 	// network interface on the backing network. It is only valid on requested node and is set
 	// only if port allocation was requested.
-	//
-	//nolint:kubeapilinter // Stable v1alpha1 retention: avoid MaxLength (would tighten validation). Avoid pointer (optionalfields).
 	ConnectionID string `json:"connectionID,omitempty"`
 
 	// IPAssignmentMode indicates how IPv4 addresses are assigned to this interface.
@@ -186,8 +148,6 @@ type NetworkInterfaceStatus struct {
 	// When set to NetworkInterfaceIPAssignmentModeDHCP, indicates IP should be obtained via DHCP.
 	// When set to NetworkInterfaceIPAssignmentModeNone, indicates no IP assignment should be performed.
 	// +optional
-	//
-	//nolint:kubeapilinter // Stable v1alpha1 retention: avoid MaxLength (would tighten validation). Avoid pointer (optionalfields).
 	IPAssignmentMode NetworkInterfaceIPAssignmentMode `json:"ipAssignmentMode,omitempty"`
 
 	// IPv6AssignmentMode indicates how IPv6 addresses are assigned to this interface.
@@ -199,8 +159,6 @@ type NetworkInterfaceStatus struct {
 	// When set to NetworkInterfaceIPAssignmentModeDHCP, indicates IPv6 should be obtained via DHCPv6.
 	// When set to NetworkInterfaceIPAssignmentModeNone, indicates no IPv6 assignment should be performed.
 	// +optional
-	//
-	//nolint:kubeapilinter // Stable v1alpha1 retention: avoid MaxLength (would tighten validation). Avoid pointer (optionalfields).
 	IPv6AssignmentMode NetworkInterfaceIPAssignmentMode `json:"ipv6AssignmentMode,omitempty"`
 }
 
@@ -242,21 +200,15 @@ const (
 // NetworkInterfacePortAllocation describes the settings for network interface port allocation request.
 type NetworkInterfacePortAllocation struct {
 	// NodeName is the node where port must be allocated for this network interface.
-	//
-	//nolint:kubeapilinter // Stable v1alpha1 retention: avoid MaxLength (would tighten validation). Avoid omitempty (requiredfields wire shape).
 	NodeName string `json:"nodeName"`
 }
 
 // NetworkInterfaceSpec defines the desired state of NetworkInterface.
 type NetworkInterfaceSpec struct {
 	// NetworkName refers to a NetworkObject in the same namespace.
-	//
-	//nolint:kubeapilinter // Stable v1alpha1 retention: keep optional string without pointer (optionalfields).
 	NetworkName string `json:"networkName,omitempty"`
 
 	// Type is the type of NetworkInterface. Supported values are vmxnet3.
-	//
-	//nolint:kubeapilinter // Stable v1alpha1 retention: avoid MaxLength (would tighten validation). Avoid pointer (optionalfields).
 	Type NetworkInterfaceType `json:"type,omitempty"`
 
 	// providerRef is a reference to a provider specific network interface object
@@ -277,8 +229,6 @@ type NetworkInterfaceSpec struct {
 	// If this field is omitted, then it is up to the underlying network
 	// provider to surface any information in status.externalID.
 	// +optional
-	//
-	//nolint:kubeapilinter // Stable v1alpha1 retention: avoid MaxLength (would tighten validation). Avoid pointer (optionalfields).
 	ExternalID string `json:"externalID,omitempty"`
 
 	// ipFamilyPolicy specifies the IP family policy for this network interface.
@@ -300,20 +250,14 @@ type NetworkInterfaceSpec struct {
 // NetworkInterfaceReference is an object that points to a NetworkInterface.
 type NetworkInterfaceReference struct {
 	// Kind is the type of resource being referenced.
-	//
-	//nolint:kubeapilinter // Stable v1alpha1 retention: avoid MaxLength (would tighten validation). Avoid omitempty (requiredfields wire shape).
 	Kind string `json:"kind"`
 
 	// Name is the name of resource being referenced.
-	//
-	//nolint:kubeapilinter // Stable v1alpha1 retention: avoid MaxLength (would tighten validation). Avoid omitempty (requiredfields wire shape).
 	Name string `json:"name"`
 
 	// APIVersion is the API version of the referent.
 	//
 	// +optional
-	//
-	//nolint:kubeapilinter // Stable v1alpha1 retention: keep optional string without pointer (optionalfields).
 	APIVersion string `json:"apiVersion,omitempty"`
 }
 
@@ -323,8 +267,6 @@ type NetworkInterfaceReference struct {
 // NetworkInterface is the Schema for the networkinterfaces API.
 // A NetworkInterface represents a user's request for network configuration to use to place a
 // VM/Pod/Container's nic on a specified network.
-//
-//nolint:kubeapilinter // Stable v1alpha1 retention: ignore kubebuilder:subresource:status marker.
 type NetworkInterface struct {
 	metav1.TypeMeta `json:",inline"`
 
@@ -333,15 +275,11 @@ type NetworkInterface struct {
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	// Spec defines the desired state of the NetworkInterface.
-	//
-	//nolint:kubeapilinter // Stable v1alpha1 retention: keep spec/status value types (optionalfields pointer churn).
 	Spec NetworkInterfaceSpec `json:"spec,omitempty"`
 
 	// Status defines the observed state of the NetworkInterface.
 	// Once NetworkInterfaceReady condition is True, it should contain configuration to use to place
 	// a VM/Pod/Container's nic on the specified network.
-	//
-	//nolint:kubeapilinter // Stable v1alpha1 retention: keep spec/status value types (optionalfields pointer churn).
 	Status NetworkInterfaceStatus `json:"status,omitempty"`
 }
 

--- a/api/v1alpha1/vmxnet3networkinterface_types.go
+++ b/api/v1alpha1/vmxnet3networkinterface_types.go
@@ -12,14 +12,10 @@ import (
 type VMXNET3NetworkInterfaceSpec struct {
 	// UPTCompatibilityEnabled indicates whether UPT(Universal Pass-through) compatibility is enabled
 	// on this network interface.
-	//
-	//nolint:kubeapilinter // Stable v1alpha1 retention: keep optional bool without pointer (optionalfields).
 	UPTCompatibilityEnabled bool `json:"uptCompatibilityEnabled,omitempty"`
 
 	// WakeOnLanEnabled indicates whether wake-on-LAN is enabled on this network interface. Clients
 	// can set this property to selectively enable or disable wake-on-LAN.
-	//
-	//nolint:kubeapilinter // Stable v1alpha1 retention: keep optional bool without pointer (optionalfields).
 	WakeOnLanEnabled bool `json:"wakeOnLanEnabled,omitempty"`
 }
 
@@ -32,8 +28,6 @@ type VMXNET3NetworkInterfaceStatus struct {
 
 // VMXNET3NetworkInterface is the Schema for the vmxnet3networkinterfaces API.
 // It represents configuration of a vSphere VMXNET3 type  network interface card.
-//
-//nolint:kubeapilinter // Stable v1alpha1 retention: ignore kubebuilder:subresource:status marker.
 type VMXNET3NetworkInterface struct {
 	metav1.TypeMeta `json:",inline"`
 
@@ -42,13 +36,9 @@ type VMXNET3NetworkInterface struct {
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	// Spec describes the desired VMXNET3 network interface configuration.
-	//
-	//nolint:kubeapilinter // Stable v1alpha1 retention: keep nested spec without omitzero (requiredfields).
 	Spec VMXNET3NetworkInterfaceSpec `json:"spec,omitempty"`
 
 	// Status reflects the observed state of the VMXNET3 network interface configuration.
-	//
-	//nolint:kubeapilinter // Stable v1alpha1 retention: keep nested status without omitzero (requiredfields).
 	Status VMXNET3NetworkInterfaceStatus `json:"status,omitempty"`
 }
 

--- a/api/v1alpha1/vspheredistributednetwork_types.go
+++ b/api/v1alpha1/vspheredistributednetwork_types.go
@@ -40,24 +40,16 @@ const (
 // VSphereDistributedNetworkCondition describes the state of a VSphereDistributedNetwork at a certain point.
 type VSphereDistributedNetworkCondition struct {
 	// Type is the type of VSphereDistributedNetwork condition.
-	//
-	//nolint:kubeapilinter // Stable v1alpha1 retention: avoid MaxLength (would tighten validation). Keep condition type without omitempty (requiredfields wire shape).
 	Type VSphereDistributedNetworkConditionType `json:"type"`
 
 	// Status is the status of the condition.
 	// Can be True, False, Unknown.
-	//
-	//nolint:kubeapilinter // Stable v1alpha1 retention: keep status without omitempty (requiredfields wire shape).
 	Status corev1.ConditionStatus `json:"status"`
 
 	// Reason is a machine understandable string that gives the reason for condition's last transition.
-	//
-	//nolint:kubeapilinter // Stable v1alpha1 retention: avoid MaxLength (would tighten validation). Avoid pointer (optionalfields).
 	Reason string `json:"reason,omitempty"`
 
 	// Message is a human-readable message indicating details about last transition.
-	//
-	//nolint:kubeapilinter // Stable v1alpha1 retention: avoid MaxLength (would tighten validation). Avoid pointer (optionalfields).
 	Message string `json:"message,omitempty"`
 
 	// lastTransitionTime provides a timestamp for when the VSphereDistributedNetwork object last transitioned from one status to another.
@@ -68,8 +60,6 @@ type VSphereDistributedNetworkCondition struct {
 // VSphereDistributedNetworkSpec defines the desired state of VSphereDistributedNetwork.
 type VSphereDistributedNetworkSpec struct {
 	// PortGroupID is an existing vSphere Distributed PortGroup identifier.
-	//
-	//nolint:kubeapilinter // Stable v1alpha1 retention: avoid MaxLength (would tighten validation). Avoid omitempty (requiredfields wire shape).
 	PortGroupID string `json:"portGroupID"`
 
 	// IPAssignmentMode selects IPv4 assignment for network interfaces. If unset, defaults to IPAssignmentModeStaticPool.
@@ -78,8 +68,6 @@ type VSphereDistributedNetworkSpec struct {
 	// and no DHCP client will be configured.
 	// Note: For IPv6 address assignment, see IPv6AssignmentMode.
 	// +optional
-	//
-	//nolint:kubeapilinter // Stable v1alpha1 retention: avoid MaxLength (would tighten validation). Avoid pointer (optionalfields).
 	IPAssignmentMode IPAssignmentModeType `json:"ipAssignmentMode,omitempty"`
 
 	// IPv6AssignmentMode selects IPv6 assignment for network interfaces. If unset, defaults to
@@ -88,37 +76,27 @@ type VSphereDistributedNetworkSpec struct {
 	// or IPAssignmentModeDHCP. This allows different assignment modes for IPv4 and IPv6, for
 	// example static IPv4 pool assignment combined with DHCPv6 for IPv6.
 	// +optional
-	//
-	//nolint:kubeapilinter // Stable v1alpha1 retention: avoid MaxLength (would tighten validation). Avoid pointer (optionalfields).
 	IPv6AssignmentMode IPAssignmentModeType `json:"ipv6AssignmentMode,omitempty"`
 
 	// IPPools references list of IPPool objects. This field should only be set when using
 	// IPAssignmentModeStaticPool. For all other modes (IPAssignmentModeDHCP, IPAssignmentModeNone),
 	// this should be set to an empty list.
-	//
-	//nolint:kubeapilinter // Stable v1alpha1 retention: avoid MaxItems (would tighten validation). Avoid omitempty (requiredfields wire shape).
 	IPPools []IPPoolReference `json:"ipPools"`
 
 	// Gateway is the gateway to use for network interfaces. This field should only be set when using
 	// IPAssignmentModeStaticPool. For all other modes (IPAssignmentModeDHCP, IPAssignmentModeNone), this should be set
 	// to an empty string.
-	//
-	//nolint:kubeapilinter // Stable v1alpha1 retention: avoid MaxLength (would tighten validation). Avoid omitempty (requiredfields wire shape).
 	Gateway string `json:"gateway"`
 
 	// SubnetMask is the subnet mask to use for network interfaces. This field should only be set when using
 	// IPAssignmentModeStaticPool. For all other modes (IPAssignmentModeDHCP, IPAssignmentModeNone), this should be set
 	// to an empty string.
-	//
-	//nolint:kubeapilinter // Stable v1alpha1 retention: avoid MaxLength (would tighten validation). Avoid omitempty (requiredfields wire shape).
 	SubnetMask string `json:"subnetMask"`
 
 	// IPv6Gateway is the IPv6 gateway to use for network interfaces. This field should only
 	// be set when using IPv6AssignmentMode IPAssignmentModeStaticPool. For all other modes
 	// (IPAssignmentModeDHCP, IPAssignmentModeNone), this should be empty/unset.
 	// +optional
-	//
-	//nolint:kubeapilinter // Stable v1alpha1 retention: avoid MaxLength (would tighten validation). Avoid pointer (optionalfields).
 	IPv6Gateway string `json:"ipv6Gateway,omitempty"`
 
 	// ipv6Prefix is the prefix length for IPv6 addresses assigned to network interfaces (e.g. 64
@@ -150,15 +128,11 @@ type VLANTrunkRange struct {
 	// Start represents the beginning of the VLAN ID range (inclusive).
 	// +kubebuilder:validation:Minimum=0
 	// +kubebuilder:validation:Maximum=4094
-	//
-	//nolint:kubeapilinter // Stable v1alpha1 retention: keep int32 range endpoints without pointers (requiredfields).
 	Start int32 `json:"start"`
 
 	// End represents the end of the VLAN ID range (inclusive).
 	// +kubebuilder:validation:Minimum=0
 	// +kubebuilder:validation:Maximum=4094
-	//
-	//nolint:kubeapilinter // Stable v1alpha1 retention: keep int32 range endpoints without pointers (requiredfields).
 	End int32 `json:"end"`
 }
 
@@ -166,8 +140,6 @@ type VLANTrunkRange struct {
 type VlanSpec struct {
 	// Type indicates the type of VLAN configuration (standard, trunk, or private).
 	// +kubebuilder:validation:Enum=standard;trunk;private
-	//
-	//nolint:kubeapilinter // Stable v1alpha1 retention: keep type without omitempty (requiredfields wire shape).
 	Type VLANType `json:"type"`
 
 	// vlanID specifies the VLAN ID when Type is VLANTypeStandard.
@@ -185,8 +157,6 @@ type VlanSpec struct {
 	// Each range's Start and End values must be between 0 and 4094 inclusive.
 	// Overlapping ranges are allowed.
 	// +optional
-	//
-	//nolint:kubeapilinter // Stable v1alpha1 retention: avoid MaxItems (would tighten validation).
 	TrunkRange []VLANTrunkRange `json:"trunkRange,omitempty"`
 
 	// privateVlanID specifies the private VLAN ID when Type is VLANTypePrivate.
@@ -209,14 +179,10 @@ const (
 // MacLearningPolicy represents the MAC learning policy configuration.
 type MacLearningPolicy struct {
 	// Enabled indicates whether MAC learning is enabled.
-	//
-	//nolint:kubeapilinter // Stable v1alpha1 retention: keep bool flags (nobools); enum would be wire-incompatible.
 	Enabled bool `json:"enabled"`
 
 	// AllowUnicastFlooding indicates whether to allow flooding of unlearned MAC for ingress traffic.
 	// +optional
-	//
-	//nolint:kubeapilinter // Stable v1alpha1 retention: keep optional bool pointer (nobools).
 	AllowUnicastFlooding *bool `json:"allowUnicastFlooding,omitempty"`
 
 	// limit represents the maximum number of MAC addresses that can be learned.
@@ -228,8 +194,6 @@ type MacLearningPolicy struct {
 	// LimitPolicy represents the policy to be used when the limit is exceeded.
 	// +optional
 	// +kubebuilder:validation:Enum=allow;drop
-	//
-	//nolint:kubeapilinter // Stable v1alpha1 retention: keep optional pointer for unset vs zero (optionalfields).
 	LimitPolicy *MacLimitPolicyType `json:"limitPolicy,omitempty"`
 }
 
@@ -238,21 +202,15 @@ type MacManagementPolicy struct {
 	// AllowPromiscuous indicates whether promiscuous mode is enabled. Determines whether or not all
 	// traffic is seen on the port.
 	// +optional
-	//
-	//nolint:kubeapilinter // Stable v1alpha1 retention: keep optional bool pointer (nobools).
 	AllowPromiscuous *bool `json:"allowPromiscuous,omitempty"`
 
 	// MacChanges specifies whether virtual machines can receive frames with a Mac Address that is different from the one configured in the VMX.
 	// +optional
-	//
-	//nolint:kubeapilinter // Stable v1alpha1 retention: keep optional bool pointer (nobools).
 	MacChanges *bool `json:"macChanges,omitempty"`
 
 	// ForgedTransmits indicates whether or not the virtual network adapter should be allowed to send
 	// network traffic with a different MAC address than the one assigned to it.
 	// +optional
-	//
-	//nolint:kubeapilinter // Stable v1alpha1 retention: keep optional bool pointer (nobools).
 	ForgedTransmits *bool `json:"forgedTransmits,omitempty"`
 
 	// macLearningPolicy represents the MAC learning policy configuration.
@@ -264,8 +222,6 @@ type MacManagementPolicy struct {
 type VSphereDistributedPortConfig struct {
 	// Vlan represents the VLAN configuration.
 	// +optional
-	//
-	//nolint:kubeapilinter // Stable v1alpha1 retention: keep json tag without omitzero (optionalfields wire shape).
 	Vlan *VlanSpec `json:"vlan,omitempty"`
 
 	// macManagementPolicy represents the MAC management policy configuration.
@@ -276,8 +232,6 @@ type VSphereDistributedPortConfig struct {
 // VSphereDistributedNetworkStatus defines the observed state of VSphereDistributedNetwork.
 type VSphereDistributedNetworkStatus struct {
 	// Conditions are an array of current observed vSphere Distributed network conditions.
-	//
-	//nolint:kubeapilinter // Stable v1alpha1 retention: keep custom VSphereDistributedNetworkCondition slice (conditions).
 	Conditions []VSphereDistributedNetworkCondition `json:"conditions,omitempty"`
 
 	// defaultPortConfig represents the default port-level configuration that applies to all ports
@@ -294,8 +248,6 @@ type VSphereDistributedNetworkStatus struct {
 
 // VSphereDistributedNetwork represents schema for a network backed by a vSphere Distributed PortGroup on vSphere
 // Distributed switch.
-//
-//nolint:kubeapilinter // Stable v1alpha1 retention: ignore kubebuilder:subresource:status marker.
 type VSphereDistributedNetwork struct {
 	metav1.TypeMeta `json:",inline"`
 
@@ -304,13 +256,9 @@ type VSphereDistributedNetwork struct {
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	// Spec defines the desired state of the VSphereDistributedNetwork.
-	//
-	//nolint:kubeapilinter // Stable v1alpha1 retention: keep spec value type (optionalfields pointer churn).
 	Spec VSphereDistributedNetworkSpec `json:"spec,omitempty"`
 
 	// Status defines the observed state of the VSphereDistributedNetwork.
-	//
-	//nolint:kubeapilinter // Stable v1alpha1 retention: keep nested status without omitzero (requiredfields).
 	Status VSphereDistributedNetworkStatus `json:"status,omitempty"`
 }
 


### PR DESCRIPTION
As kube-api-linter is built on golangci-lint, the flag `--new-from-merge-base` may be used, which allows the introduction of the linter without major changes to existing structures.

As such, we can remove previous `nolint` directives as unchanged structures will remain accurate. This ensures that new changes to existing CRDs will be caught by the linter moving forward.

Testing Done: `make lint-kal`.