### PR TITLE
Revert CEL rule for default IP assignment mode in VsphereDistributedNetwork

### DIFF
--- a/api/v1alpha1/vspheredistributednetwork_types.go
+++ b/api/v1alpha1/vspheredistributednetwork_types.go
@@ -67,20 +67,19 @@ type VSphereDistributedNetworkCondition struct {
 // +kubebuilder:validation:XValidation:rule="(has(self.ipAssignmentMode) && (self.ipAssignmentMode == 'dhcp' || self.ipAssignmentMode == 'none')) ? (!has(self.subnetMask) || self.subnetMask == '') : true",message="SubnetMask must be empty when IpAssignmentMode is dhcp or none"
 // +kubebuilder:validation:XValidation:rule="(has(self.ipAssignmentMode) && (self.ipAssignmentMode == 'dhcp' || self.ipAssignmentMode == 'none')) ? (!has(self.addressRanges) || size(self.addressRanges) == 0) : true",message="AddressRanges must be empty when IpAssignmentMode is dhcp or none"
 // +kubebuilder:validation:XValidation:rule="(has(self.ipAssignmentMode) && (self.ipAssignmentMode == 'dhcp' || self.ipAssignmentMode == 'none')) ? (!has(self.ipPools) || size(self.ipPools) == 0) : true",message="IPPools must be empty when IpAssignmentMode is dhcp or none"
-// +kubebuilder:validation:XValidation:rule="(!has(self.ipAssignmentMode) || self.ipAssignmentMode == 'staticpool') ? (has(self.gateway) && self.gateway != '') : true",message="Gateway is required when IpAssignmentMode is staticpool"
-// +kubebuilder:validation:XValidation:rule="(!has(self.ipAssignmentMode) || self.ipAssignmentMode == 'staticpool') ? (has(self.subnetMask) && self.subnetMask != '') : true",message="SubnetMask is required when IpAssignmentMode is staticpool"
+// +kubebuilder:validation:XValidation:rule="(has(self.ipAssignmentMode) && self.ipAssignmentMode == 'staticpool') ? (has(self.gateway) && self.gateway != '') : true",message="Gateway is required when IpAssignmentMode is staticpool"
+// +kubebuilder:validation:XValidation:rule="(has(self.ipAssignmentMode) && self.ipAssignmentMode == 'staticpool') ? (has(self.subnetMask) && self.subnetMask != '') : true",message="SubnetMask is required when IpAssignmentMode is staticpool"
 // VSphereDistributedNetworkSpec defines the desired state of VSphereDistributedNetwork.
 type VSphereDistributedNetworkSpec struct {
 	// PortGroupID is an existing vSphere Distributed PortGroup identifier.
 	PortGroupID string `json:"portGroupID"`
 
-	// IPAssignmentMode to use for IPv4 addresses on network interfaces. If unset, defaults to IPAssignmentModeStaticPool.
+	// ipAssignmentMode to use for IPv4 addresses on network interfaces.
 	// For IPAssignmentModeDHCP and IPAssignmentModeNone, the IPv4 IPPools, Gateway and SubnetMask
 	// fields should be empty/unset. When using IPAssignmentModeNone, no IPv4 IP will be assigned
 	// and no DHCP client will be configured.
 	// Note: For IPv6 address assignment, see IPv6AssignmentMode.
 	// +kubebuilder:validation:Enum=dhcp;staticpool;none
-	// +kubebuilder:default:=staticpool
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="ipAssignmentMode is immutable"
 	// +optional
 	IPAssignmentMode IPAssignmentModeType `json:"ipAssignmentMode,omitempty"`

--- a/api/v1alpha1/vspheredistributednetwork_types.go
+++ b/api/v1alpha1/vspheredistributednetwork_types.go
@@ -67,8 +67,8 @@ type VSphereDistributedNetworkCondition struct {
 // +kubebuilder:validation:XValidation:rule="(has(self.ipAssignmentMode) && (self.ipAssignmentMode == 'dhcp' || self.ipAssignmentMode == 'none')) ? (!has(self.subnetMask) || self.subnetMask == '') : true",message="SubnetMask must be empty when IpAssignmentMode is dhcp or none"
 // +kubebuilder:validation:XValidation:rule="(has(self.ipAssignmentMode) && (self.ipAssignmentMode == 'dhcp' || self.ipAssignmentMode == 'none')) ? (!has(self.addressRanges) || size(self.addressRanges) == 0) : true",message="AddressRanges must be empty when IpAssignmentMode is dhcp or none"
 // +kubebuilder:validation:XValidation:rule="(has(self.ipAssignmentMode) && (self.ipAssignmentMode == 'dhcp' || self.ipAssignmentMode == 'none')) ? (!has(self.ipPools) || size(self.ipPools) == 0) : true",message="IPPools must be empty when IpAssignmentMode is dhcp or none"
-// +kubebuilder:validation:XValidation:rule="(has(self.ipAssignmentMode) && self.ipAssignmentMode == 'staticpool') ? (has(self.gateway) && self.gateway != '') : true",message="Gateway is required when IpAssignmentMode is staticpool"
-// +kubebuilder:validation:XValidation:rule="(has(self.ipAssignmentMode) && self.ipAssignmentMode == 'staticpool') ? (has(self.subnetMask) && self.subnetMask != '') : true",message="SubnetMask is required when IpAssignmentMode is staticpool"
+// +kubebuilder:validation:XValidation:rule="(!has(self.ipAssignmentMode) || self.ipAssignmentMode == 'staticpool') ? (has(self.gateway) && self.gateway != '') : true",message="Gateway is required when IpAssignmentMode is staticpool or unset"
+// +kubebuilder:validation:XValidation:rule="(!has(self.ipAssignmentMode) || self.ipAssignmentMode == 'staticpool') ? (has(self.subnetMask) && self.subnetMask != '') : true",message="SubnetMask is required when IpAssignmentMode is staticpool or unset"
 // VSphereDistributedNetworkSpec defines the desired state of VSphereDistributedNetwork.
 type VSphereDistributedNetworkSpec struct {
 	// PortGroupID is an existing vSphere Distributed PortGroup identifier.


### PR DESCRIPTION
Undo a change where we set a default IP assignment mode to VDNs that don't explicitly assign one - to static. The previous change breaks existing writers who don't supply any IP mode at all, and when comparing diffs, expects that field to be empty.

Testing Done:

On live Control Plane, applied this new CRD, and verified that creating a CR with no IP assignment mode set maintains it as unset:
```
root@423336eca0cdbafc331a45b20bf829b1 [ ~ ]# cat test-vds-no-mode.yaml 
...
spec:
  # No ipAssignmentMode specified - this should remain empty/unset
  gateway: 172.16.1.1
  ipPools:
  - apiVersion: v1alpha1
    name: test-pool-172-16-1-2
  portGroupID: dvportgroup-51
  subnetMask: 255.255.0.0
root@423336eca0cdbafc331a45b20bf829b1 [ ~ ]# k apply -f test-vds-no-mode.yaml  --kubeconfig /etc/kubernetes/admin.conf
vspheredistributednetwork.netoperator.vmware.com/test-network-no-mode created
root@423336eca0cdbafc331a45b20bf829b1 [ ~ ]# k get vspheredistributednetworks test-network-no-mode -o yaml
...
spec:
  gateway: 172.16.1.1
  ipPools:
  - apiVersion: v1alpha1
    name: test-pool-172-16-1-2
  portGroupID: dvportgroup-51
  subnetMask: 255.255.0.0
status:
...
Also, creating a VDN without any IP mode, but also without subnet mask or gateway is disallowed:

root@423336eca0cdbafc331a45b20bf829b1 [ ~ ]# cat test-invalid-no-gateway-or-subnet.yaml 
apiVersion: netoperator.vmware.com/v1alpha1
kind: VSphereDistributedNetwork
metadata:
  name: test-network-no-mode
  annotations:
    vmware-system-dvs-uuid: 50 33 4b 74 45 61 e6 cb-5a e8 b2 dd ec 4c e9 9f
spec:
  # No ipAssignmentMode specified - this should remain empty/unset
  ipPools:
  - apiVersion: v1alpha1
    name: test-pool-172-16-1-2
  portGroupID: dvportgroup-51
root@423336eca0cdbafc331a45b20bf829b1 [ ~ ]# k apply -f test-invalid-no-gateway-or-subnet.yaml  --kubeconfig /etc/kubernetes/admin.conf
The VSphereDistributedNetwork "test-network-no-mode" is invalid: 
* spec: Invalid value: "object": Gateway is required when IpAssignmentMode is staticpool or unset
* spec: Invalid value: "object": SubnetMask is required when IpAssignmentMode is staticpool or unset

In addition, before applying this CRD, the error "Failed to update VSphere Distributed Network object" kept showing up. But after updating the CRD, it eventually stopped.