### PR TITLE
Make NetworkSettings.provider immutable

### DIFF
--- a/api/v1alpha1/networksettings_types.go
+++ b/api/v1alpha1/networksettings_types.go
@@ -9,6 +9,8 @@ import (
 )
 
 // NetworkSettingsProvider is the active network provider type for a namespace.
+//
+// +kubebuilder:validation:Enum=vsphere-distributed;nsx-tier1;vpc
 type NetworkSettingsProvider string
 
 const (
@@ -39,8 +41,10 @@ type NetworkSettings struct {
 	// including when choosing defaulting behavior or which provider-specific APIs to use when not
 	// otherwise specified.
 	//
+	// Once set, the provider is immutable.
+	//
 	// +required
-	// +kubebuilder:validation:Enum=vsphere-distributed;nsx-tier1;vpc
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="provider is immutable once set"
 	Provider NetworkSettingsProvider `json:"provider,omitempty"`
 }
 


### PR DESCRIPTION
Add a CEL XValidation rule (self == oldSelf) to the Provider field so that the API server rejects any attempt to change the provider once it has been set.  The Enum marker is also repositioned from the field to the NetworkSettingsProvider type, which is the idiomatic location for a named-string type whose valid values are defined by its constants.

The field description is updated to surface the immutability constraint to consumers.  This restriction may be relaxed in the future to permit certain upgrade paths (e.g. vsphere-distributed or nsx-tier1 to vpc).

Testing Done:

* [x] `make lint-kal`.
* [x] Downstream testing - verified that once I've set this value, it is not changeable.