### PR TITLE
Add `legacyProvider` notion to NetworkSettings

### DIFF
--- a/api/v1alpha1/networksettings_types.go
+++ b/api/v1alpha1/networksettings_types.go
@@ -11,7 +11,7 @@ import (
 // +genclient
 // +kubebuilder:object:root=true
 // +kubebuilder:resource:scope=Namespaced
-// +kubebuilder:validation:XValidation:rule="!has(self.previousProvider) || self.previousProvider != self.provider",message="previousProvider must differ from provider"
+// +kubebuilder:validation:XValidation:rule="!has(self.legacyProvider) || self.legacyProvider != self.provider",message="legacyProvider must differ from provider"
 //
 // NetworkSettings exposes information about the effective network configuration for a namespace.
 // This is observed, realized state, and its contents may be updated by further network configuration
@@ -31,22 +31,17 @@ type NetworkSettings struct {
 	// +required
 	Provider NetworkProvider `json:"provider,omitempty"`
 
-	// previousProvider is the network provider this namespace used immediately before
-	// transitioning to the current provider. When set, the migration from previousProvider
-	// to provider is either in progress or has recently completed; resources associated with
-	// the previous provider (such as Network objects originally backed by VSphereDistributedNetwork)
-	// may still exist in this namespace and require continued validation and reconciliation.
+	// legacyProvider is the network provider to which this namespace was previously affined.
+	// When set, the namespace has transitioned from legacyProvider to the current provider.
+	// APIs and resources associated with legacyProvider remain functional within this namespace
+	// but are no longer the governing provider; new network resources will be created under
+	// the current provider's APIs.
 	//
-	// Operators that serve resources for multiple providers should continue to validate and
-	// reconcile resources associated with previousProvider's APIs until this field is cleared.
-	// Net Operator clears this field once all resources belonging to the previous provider
-	// have been removed from the namespace.
-	//
-	// This field is absent when the namespace has never undergone a provider transition, or
-	// after a transition has fully completed and all prior-provider resources are gone.
+	// This field is absent when the namespace has never undergone a provider transition.
 	//
 	// +optional
-	PreviousProvider NetworkProvider `json:"previousProvider,omitempty"`
+	// +kubebuilder:validation:XValidation:rule="self in ['vsphere-distributed', 'nsx-tier1']",message="legacyProvider must be vsphere-distributed or nsx-tier1"
+	LegacyProvider NetworkProvider `json:"legacyProvider,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/api/v1alpha1/networksettings_types.go
+++ b/api/v1alpha1/networksettings_types.go
@@ -11,6 +11,7 @@ import (
 // +genclient
 // +kubebuilder:object:root=true
 // +kubebuilder:resource:scope=Namespaced
+// +kubebuilder:validation:XValidation:rule="!has(self.legacyProvider) || self.legacyProvider != self.provider",message="legacyProvider must differ from provider"
 //
 // NetworkSettings exposes information about the effective network configuration for a namespace.
 // This is observed, realized state, and its contents may be updated by further network configuration
@@ -29,6 +30,23 @@ type NetworkSettings struct {
 	//
 	// +required
 	Provider NetworkProvider `json:"provider,omitempty"`
+
+	// legacyProvider is the network provider this namespace used immediately before
+	// transitioning to the current provider. When set, the migration from legacyProvider
+	// to provider is either in progress or has recently completed; resources associated with
+	// the legacy provider (such as Network objects originally backed by VSphereDistributedNetwork)
+	// may still exist in this namespace and require continued validation and reconciliation.
+	//
+	// Operators that serve resources for multiple providers should continue to validate and
+	// reconcile resources associated with legacyProvider's APIs until this field is cleared.
+	// Net Operator clears this field once all resources belonging to the legacy provider
+	// have been removed from the namespace.
+	//
+	// This field is absent when the namespace has never undergone a provider transition, or
+	// after a transition has fully completed and all prior-provider resources are gone.
+	//
+	// +optional
+	LegacyProvider NetworkProvider `json:"legacyProvider,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/api/v1alpha1/networksettings_types.go
+++ b/api/v1alpha1/networksettings_types.go
@@ -11,7 +11,7 @@ import (
 // +genclient
 // +kubebuilder:object:root=true
 // +kubebuilder:resource:scope=Namespaced
-// +kubebuilder:validation:XValidation:rule="!has(self.legacyProvider) || self.legacyProvider != self.provider",message="legacyProvider must differ from provider"
+// +kubebuilder:validation:XValidation:rule="!has(self.previousProvider) || self.previousProvider != self.provider",message="previousProvider must differ from provider"
 //
 // NetworkSettings exposes information about the effective network configuration for a namespace.
 // This is observed, realized state, and its contents may be updated by further network configuration
@@ -31,22 +31,22 @@ type NetworkSettings struct {
 	// +required
 	Provider NetworkProvider `json:"provider,omitempty"`
 
-	// legacyProvider is the network provider this namespace used immediately before
-	// transitioning to the current provider. When set, the migration from legacyProvider
+	// previousProvider is the network provider this namespace used immediately before
+	// transitioning to the current provider. When set, the migration from previousProvider
 	// to provider is either in progress or has recently completed; resources associated with
-	// the legacy provider (such as Network objects originally backed by VSphereDistributedNetwork)
+	// the previous provider (such as Network objects originally backed by VSphereDistributedNetwork)
 	// may still exist in this namespace and require continued validation and reconciliation.
 	//
 	// Operators that serve resources for multiple providers should continue to validate and
-	// reconcile resources associated with legacyProvider's APIs until this field is cleared.
-	// Net Operator clears this field once all resources belonging to the legacy provider
+	// reconcile resources associated with previousProvider's APIs until this field is cleared.
+	// Net Operator clears this field once all resources belonging to the previous provider
 	// have been removed from the namespace.
 	//
 	// This field is absent when the namespace has never undergone a provider transition, or
 	// after a transition has fully completed and all prior-provider resources are gone.
 	//
 	// +optional
-	LegacyProvider NetworkProvider `json:"legacyProvider,omitempty"`
+	PreviousProvider NetworkProvider `json:"previousProvider,omitempty"`
 }
 
 // +kubebuilder:object:root=true


### PR DESCRIPTION
When a namespace migrates from one network provider to another (e.g. vsphere-distributed → vpc), NetworkSettings.provider immediately reflects the new active provider. However, resources belonging to the previous provider — Networks, VSphereDistributedNetworks, and their underlying infrastructure — may still exist in the namespace and require continued validation and reconciliation until they are fully removed.

This change introduces the optional legacyProvider field on NetworkSettings to record the provider a namespace used immediately before its current one. When set, it means that "network-aware" operators should honor `provider` for all new workloads by default, but that some workloads (brownfield or explicit) may still reference `legacyProvider` API groups.

A CEL rule enforces that legacyProvider, when present, must differ from the active provider — the one structural invariant that is always meaningful regardless of when or how a write occurs. No stricter oldSelf-based constraint is added: the responsibility for when to set and clear this field belongs to the controller, and a cross-update rule would incorrectly reject valid writes on reconcile loops where provider has not changed but legacyProvider is still legitimately set awaiting cleanup.