### PR TITLE
Fix 'make generate'

### DIFF
--- a/hack/client-gen.sh
+++ b/hack/client-gen.sh
@@ -17,18 +17,19 @@ CLIENTSET_NAME=clientset
 HEADER_FILE=hack/boilerplate/boilerplate.go.txt
 
 $TOOLS_PATH/client-gen --go-header-file $HEADER_FILE --input-base $PKG/api --input /$VERSION \
-    --clientset-path $CLIENTGEN_PATH --clientset-name $CLIENTSET_NAME
+    --output-base $TOPLEVEL --output-package $CLIENTGEN_PATH --clientset-name $CLIENTSET_NAME
 
 mv "$TOPLEVEL/$PKG/pkg/client/clientset_generated/clientset/typed/v1alpha1/_client.go" "$TOPLEVEL/$PKG/pkg/client/clientset_generated/clientset/typed/v1alpha1/client.go"
 
-$TOOLS_PATH/lister-gen --input-dirs $PKG/api/$VERSION --go-header-file $HEADER_FILE --output-package $LISTERGEN_PATH
+$TOOLS_PATH/lister-gen --input-dirs $PKG/api/$VERSION --go-header-file $HEADER_FILE \
+    --output-base $TOPLEVEL --output-package $LISTERGEN_PATH
 
 $TOOLS_PATH/informer-gen --single-directory --input-dirs $PKG/api/$VERSION --go-header-file $HEADER_FILE \
-    --output-package $INFORMERGEN_PATH --listers-package $LISTERGEN_PATH --versioned-clientset-package $CLIENTGEN_PATH/$CLIENTSET_NAME
+    --output-base $TOPLEVEL --output-package $INFORMERGEN_PATH --listers-package $LISTERGEN_PATH --versioned-clientset-package $CLIENTGEN_PATH/$CLIENTSET_NAME
 
 # Move to top level so that samples can consume the via the top-level import.
 # while taking care to avoid other artifacts potentially in pkg.
 mkdir -p "$TOPLEVEL/pkg/client"
-rm -rf "$TOPLEVEL/pkg/client/*_generated"
-mv -f "$TOPLEVEL/$PKG/pkg/client/*" pkg/client
+rm -rf $TOPLEVEL/pkg/client/*_generated
+mv -f $TOPLEVEL/$PKG/pkg/client/* pkg/client
 rm -rf "$TOPLEVEL"/github.com


### PR DESCRIPTION
`make generate` from repo root was failing due to broken hack/client-gen.sh

hack/client-gen.sh had three bugs that prevented make generate from working on a clean checkout:

- client-gen --clientset-path was renamed to --output-package in k8s.io/code-generator v0.29. Without this fix the generator errors immediately.
- All three generators defaulted --output-base to $GOPATH/src, so generated files landed in $GOPATH rather than the repo when $GOPATH was set. Adding --output-base $TOPLEVEL makes the output location consistent regardless of $GOPATH.
- The cleanup rm -rf and mv -f lines used glob patterns inside double-quoted strings ("…/*_generated", "…/*"), which bash does not expand. The rm silently no-oped (due to -f) but the mv would fail with No such file or directory on a clean run, leaving generated output stranded under a temporary github.com/ directory. Removing the quotes lets bash expand the globs correctly.

There is no known consumer of clientset generated by this make target. In the future, we could consider removing the generation altogether. 

Testing Done:
```
$ go version
go version go1.26.3 linux/amd64

$ make clean
...

$ make generate
...
hack/client-gen.sh
W0605 13:12:33.434663 2460953 parse.go:863] Making unsupported type entry "any" for: &types.Alias{obj:(*types.TypeName)(0x332272f74b90), orig:(*types.Alias)(0x332272f36080), tparams:(*types.TypeParamList)(nil), targs:(*types.TypeList)(nil), fromRHS:(*types.Interface)(0x332272f74af0), actual:(*types.Interface)(0x332272f74af0)}
W0605 13:12:33.435239 2460953 parse.go:863] Making unsupported type entry "reflect.uncommonType" for: &types.Alias{obj:(*types.TypeName)(0x3322735c4c30), orig:(*types.Alias)(0x332275d70880), tparams:(*types.TypeParamList)(nil), targs:(*types.TypeList)(nil), fromRHS:(*types.Named)(0x332273901e00), actual:(*types.Named)(0x332273901e00)}
W0605 13:12:36.286209 2462463 parse.go:863] Making unsupported type entry "any" for: &types.Alias{obj:(*types.TypeName)(0x9154664ab90), orig:(*types.Alias)(0x9154656a0c0), tparams:(*types.TypeParamList)(nil), targs:(*types.TypeList)(nil), fromRHS:(*types.Interface)(0x9154664aaf0), actual:(*types.Interface)(0x9154664aaf0)}
W0605 13:12:36.286837 2462463 parse.go:863] Making unsupported type entry "reflect.uncommonType" for: &types.Alias{obj:(*types.TypeName)(0x91549d311d0), orig:(*types.Alias)(0x9154a53a580), tparams:(*types.TypeParamList)(nil), targs:(*types.TypeList)(nil), fromRHS:(*types.Named)(0x91547507b00), actual:(*types.Named)(0x91547507b00)}
W0605 13:12:38.737559 2463864 parse.go:863] Making unsupported type entry "any" for: &types.Alias{obj:(*types.TypeName)(0x18866c2f6b90), orig:(*types.Alias)(0x18866c2b6080), tparams:(*types.TypeParamList)(nil), targs:(*types.TypeList)(nil), fromRHS:(*types.Interface)(0x18866c2f6af0), actual:(*types.Interface)(0x18866c2f6af0)}
W0605 13:12:38.738108 2463864 parse.go:863] Making unsupported type entry "reflect.uncommonType" for: &types.Alias{obj:(*types.TypeName)(0x18866e568d20), orig:(*types.Alias)(0x18866fae57c0), tparams:(*types.TypeParamList)(nil), targs:(*types.TypeList)(nil), fromRHS:(*types.Named)(0x18866c7cb180), actual:(*types.Named)(0x18866c7cb180)}
make[1]: Leaving directory 'net-operator-api'
```