### PR TITLE
Remove unneeded  top-level status.observedGeneration from NNC

### DIFF
--- a/api/v1alpha1/namespacenetworkconfiguration_types.go
+++ b/api/v1alpha1/namespacenetworkconfiguration_types.go
@@ -146,14 +146,6 @@ type NamespaceNetworkStatus struct {
 	// +listMapKey=type
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 
-	// observedGeneration is the metadata.generation that this status was
-	// computed from. Clients must compare this against metadata.generation
-	// before relying on any field in status; if they differ, the status
-	// reflects a prior spec version and should be treated as stale.
-	//
-	// +optional
-	ObservedGeneration *int64 `json:"observedGeneration,omitempty"`
-
 	// associatedNamespaces lists each Namespace currently associated with this
 	// NamespaceNetworkConfiguration and its individual reconciliation state. Net
 	// Operator updates this list as Namespaces are attached or detached via the
@@ -185,8 +177,7 @@ type NamespaceNetworkStatus struct {
 // resources into associated Namespaces, and creates a NetworkSettings CR in each
 // Namespace to expose the active provider to network-aware operators.
 //
-// Deletion is blocked by the
-// netoperator.vmware.com/namespace-network-configuration-protection finalizer
+// Deletion is blocked by the netoperator.vmware.com/nnc-protection  finalizer
 // while any Namespace holds the netoperator.vmware.com/network-configuration
 // label pointing to this resource.
 //

--- a/api/v1alpha1/namespacenetworkconfiguration_types.go
+++ b/api/v1alpha1/namespacenetworkconfiguration_types.go
@@ -177,7 +177,7 @@ type NamespaceNetworkStatus struct {
 // resources into associated Namespaces, and creates a NetworkSettings CR in each
 // Namespace to expose the active provider to network-aware operators.
 //
-// Deletion is blocked by the netoperator.vmware.com/nnc-protection  finalizer
+// Deletion is blocked by the netoperator.vmware.com/nnc-protection finalizer
 // while any Namespace holds the netoperator.vmware.com/network-configuration
 // label pointing to this resource.
 //

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -997,11 +997,6 @@ func (in *NamespaceNetworkStatus) DeepCopyInto(out *NamespaceNetworkStatus) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
-	if in.ObservedGeneration != nil {
-		in, out := &in.ObservedGeneration, &out.ObservedGeneration
-		*out = new(int64)
-		**out = **in
-	}
 	if in.AssociatedNamespaces != nil {
 		in, out := &in.AssociatedNamespaces, &out.AssociatedNamespaces
 		*out = make([]NamespaceNetworkAssociation, len(*in))


### PR DESCRIPTION
**Summary**
This PR removes the unneeded top-level status.observedGeneration field from the NamespaceNetworkConfiguration (NNC) CRD and corrects outdated finalizer references in the documentation comments.

**Key Changes**

1. API Schema Cleanup:
Removed ObservedGeneration *int64 from NamespaceNetworkStatus in api/v1alpha1/namespacenetworkconfiguration_types.go.
The top-level observedGeneration is redundant because the standard metav1.Conditions (under status.conditions) already carry their own observedGeneration fields. Removing this simplifies the status schema.

2. Comment Correction:
Updated the NNC struct doc comments to reference the correct finalizer name `netoperator.vmware.com/nnc-protection` (matching the actual code constant NamespaceNetworkProtectionFinalizer), replacing the outdated `netoperator.vmware.com/namespace-network-configuration-protection` reference.